### PR TITLE
Fix libxml2-utils dependency fetch

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -64,7 +64,8 @@ jobs:
         name: Generate Build Context
         run: |
           # TODO(compnerd) can we make this more silent?
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --fix-missing -o Dpkg::Use-Pty=0 install -yq repo libxml2-utils
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update -yq
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -o Dpkg::Use-Pty=0 install -yq repo libxml2-utils
 
           repo init --quiet --groups default --depth 1 -u https://github.com/compnerd/swift-build
           repo sync --quiet --no-clone-bundle --no-tags --jobs $(nproc --all)


### PR DESCRIPTION
apt-get cache is outdated, pointing to a version of
libxml2-utils that is not available anymore on ubuntu servers.

This PR runs `apt-get update` before `apt-get install`, which
should ensure it is always up to date.
