### PR TITLE
compress compilers before upload

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -579,18 +579,20 @@ jobs:
 
       - name: Zip Compilers Before Upload
         run: |
-          $zip = "${{ github.workspace }}/BinaryCache/swift-windows-${{ matrix.arch }}.zip"
           $path = "${{ github.workspace }}/BuildRoot/Library"
-          Remove-Item -Path "${{ github.workspace }}/BuildRoot/Library/icu-69.1" -Recurse -Force
+          $zip = "${{ github.workspace }}/BinaryCache/swift-windows-${{ matrix.arch }}.zip"
+          $icu_path = "${{ github.workspace }}/BuildRoot/Library/icu-69.1"
+          dir $path
+          if (test-path "$icu_path") {
+            Remove-Item -Path "${{ github.workspace }}/BuildRoot/Library/icu-69.1" -Recurse -Force
+          }
           Compress-Archive -Path $path -DestinationPath $zip -CompressionLevel Optimal
 
       - name: Upload Compilers
         uses: actions/upload-artifact@v3
         with:
           name: compilers-${{ matrix.arch }}
-          path: |
-            ${{ github.workspace }}/BuildRoot/Library
-            !${{ github.workspace }}/BuildRoot/Library/icu-69.1
+          path: "${{ github.workspace }}/BinaryCache/swift-windows-${{ matrix.arch }}.zip"
 
       # TODO(compnerd) this takes ~1h due to the size, see if we can compress first
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
We see the upload of compilers taking up to 50% of the pipeline's time. Let's try to improve by compressing this first.