### PR TITLE
GHA: add SwiftFormat as part of the toolchain build

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2021,6 +2021,82 @@ jobs:
           name: swift-format.exe
           path: ${{ github.workspace }}/SourceCache/swift-format/.build/release/swift-format.exe
 
+  SwiftFormat:
+    runs-on: windows-latest
+    needs: [context, installer]
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: installer-amd64
+          path: ${{ github.workspace }}/tmp
+
+      # TODO(compnerd) can this be done via a re-usage workflow for SwiftFormat?
+
+      # TODO(compnerd): migrate this to compnerd/gha-setup-swift after the work that @mangini is doing is completed
+      - run: |
+          function Update-EnvironmentVariables {
+            foreach ($level in "Machine", "User") {
+              [Environment]::GetEnvironmentVariables($level).GetEnumerator() | % {
+                # For Path variables, append the new values, if they're not already in there
+                if ($_.Name -Match 'Path$') {
+                  $_.Value = ($((Get-Content "Env:$($_.Name)") + ";$($_.Value)") -Split ';' | Select -Unique) -Join ';'
+                }
+                $_
+              } | Set-Content -Path { "Env:$($_.Name)" }
+            }
+          }
+
+          try {
+            Write-Host "Starting Install installer.exe..."
+            $Process = Start-Process -FilePath ${{ github.workspace }}/tmp/installer.exe -ArgumentList ("-q") -Wait -PassThru
+            $ExitCode = $Process.ExitCode
+            if ($ExitCode -eq 0 -or $ExitCode -eq 3010) {
+              Write-Host "Installation successful"
+            } else {
+              Write-Host "non-zero exit code returned by the installation process: $ExitCode"
+              exit $ExitCode
+            }
+          } catch {
+            Write-Host "Failed to install: $($_.Exception.Message)"
+            exit 1
+          }
+          Update-EnvironmentVariables
+
+          # Reset Path and environment
+          echo "$env:Path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+          Get-ChildItem Env: | % { echo "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append }
+
+      - uses: actions/checkout@v3
+        with:
+          repository: nicklockwood/SwiftFormat
+          ref: refs/tags/0.51.11
+          path: ${{ github.workspace }}/SourceCache/SwiftFormat
+
+      - run: swift test
+        working-directory: ${{ github.workspace }}/SourceCache/SwiftFormat
+
+      - run: swift build -c release -Xswiftc -gnone
+        working-directory: ${{ github.workspace }}/SourceCache/SwiftFormat
+
+      - uses: actions/checkout@v3
+        with:
+          path: ${{ github.workspace }}/SourceCache/swift-build
+
+      - uses: microsoft/setup-msbuild@v1.3.1
+
+      - run: msbuild ${{ github.workspace }}/SourceCache/swift-build/installer-scripts/SwiftFormat.wixproj -nologo -restore -p:Configuration=Release -p:SWIFTFORMAT_BUILD=${{ github.workspace }}\SourceCache\SwiftFormat\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: SwiftFormat-msi
+          path: ${{ github.workspace }}/artifacts/SwiftFormat.msi
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: SwiftFormat.exe
+          path: ${{ github.workspace }}/SourceCache/swift-format/.build/release/SwiftFormat.exe
+
   snapshot:
     runs-on: ubuntu-latest
     needs: [context, swift_format]
@@ -2045,7 +2121,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [smoke_test, swift_format]
+    needs: [smoke_test, swift_format, SwiftFormat]
 
     steps:
       - uses: actions/download-artifact@v3
@@ -2088,4 +2164,11 @@ jobs:
           asset_name: swift-format.msi
           asset_path: ${{ github.workspace }}/tmp/swift-format.msi
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-
+      - uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_content_type: application/octet-stream
+          asset_name: SwiftFormat.msi
+          asset_path: ${{ github.workspace }}/tmp/SwiftFormat.msi
+          upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
Because we do not have a stable ABI on Windows and the toolchain is still under rapid development, build and package a version of SwiftFormat for developers to install locally for productivity.  This is a divergence from the upstream toolchain.  Ideally, this will be removed and subsumed by the nicklockwood/SwiftFormat repository.