### PR TITLE
Update swift-toolchain.yml

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2118,7 +2118,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: SwiftFormat.exe
-          path: ${{ github.workspace }}/SourceCache/SwiftFormat/.build/release/SwiftFormat.exe
+          path: ${{ github.workspace }}/SourceCache/SwiftFormat/.build/x86_64-unknown-windows-msvc/release/SwiftFormat.exe
 
   swift_inspect:
     runs-on: windows-latest


### PR DESCRIPTION
Repair the artifact upload handling.  The action does not support symbolic links.