### PR TITLE
Update swift-toolchain.yml

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2100,7 +2100,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: nicklockwood/SwiftFormat
-          ref: refs/tags/0.51.11
+          ref: 17587191b4a9a8acd86f9120d952e6eeccbf5931
           path: ${{ github.workspace }}/SourceCache/SwiftFormat
 
       - run: swift test


### PR DESCRIPTION
Pin SwiftFormat to 17587191b4a9a8acd86f9120d952e6eeccbf5931 (#1486) so that we can use this on Windows remotely with VSCode integration.