### PR TITLE
Add runtime-amd64.msi to release

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2249,11 +2249,6 @@ jobs:
         with:
           name: runtime-windows-amd64-msi
           path: ${{ github.workspace }}/tmp/amd64
-  
-      - uses: actions/download-artifact@v3
-        with:
-          name: SwiftFormat-msi
-          path: ${{ github.workspace }}/tmp
 
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This is so we can get rid of the checked-in `Swift Runtime.msi` for the arc installer by downloading it before the installer build.

Eventually I expect our releases would include the 3 runtime MSMs, so this gets us one small step closer.