### PR TITLE
GHA: add a workflow for building and releasing SwiftLint

### DIFF
--- a/.github/workflows/SwiftLint.yml
+++ b/.github/workflows/SwiftLint.yml
@@ -1,0 +1,60 @@
+name: SwiftLint
+
+on:
+  workflow_dispatch:
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        include:
+          - branch: development
+            tag: DEVELOPMENT-SNAPSHOT-2023-07-10-a
+
+    steps:
+      # Build
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: refs/heads/compnerd/windows
+          repository: thebrowsercompany/SwiftLint
+
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: ${{ matrix.branch }}
+          tag: ${{ matrix.tag }
+
+      - name: test
+        run: swift test
+
+      - name: build
+        run: swift build -c release -debug-info-format none
+
+      # Package
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: refs/heads/main
+          path: ${{ github.workspace }}/SourceCache/swift-build
+
+      - uses: microsoft/setup-msbuild@v1.3.1
+
+      - name: package
+        run: msbuild ${{ github.workspace }}/SourceCache/swift-build/platforms/Windows/SwiftLint.wixproj -nologo -restore -p:Configuration=Release -p:SWIFT_LINT_BUILD=${{ github.workspace }}\.build\release -p:OutputPath=${{ github.workspace }}\artifacts -p:RunWixToolsOutOfProc=true
+
+      # Release
+      - run: |
+          $MSI_PATH = cygpath -m ${{ github.workspace }}\artifacts\SwiftLint.msi
+          Write-Output MSI_PATH=${MSI_PATH} | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: true
+          name: SwiftLint-${{ matrix.tag }}
+          tag_name: SwiftLint-${{ matrix.tag }}
+          files:
+            .build/x86_64-unknown-windows-msvc/release/SwiftLint.exe
+            ${{ env.MSI_PATH }}

--- a/platforms/Windows/SwiftLint.wixproj
+++ b/platforms/Windows/SwiftLint.wixproj
@@ -1,0 +1,47 @@
+<Project Sdk="WixToolset.Sdk/4.0.0">
+  <PropertyGroup>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProductArchitecture Condition=" '$(ProductArchitecture)' == '' ">amd64</ProductArchitecture>
+    <ProductArchitecture>$(ProductArchitecture)</ProductArchitecture>
+
+    <ProductVersion Condition=" '$(ProductVersion)' == '' ">0.0.0</ProductVersion>
+    <ProductVersion>$(ProductVersion)</ProductVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputPath>build\</OutputPath>
+    <IntermediateOutputPath>build\obj\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <!-- <Import Project="WiXCodeSigning.targets" /> -->
+
+  <PropertyGroup>
+    <DefineConstants>ProductArchitecture=$(ProductArchitecture);ProductVersion=$(ProductVersion);SWIFT_LINT_BUILD=$(SWIFT_LINT_BUILD)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'amd64' ">
+    <InstallerPlatform>x64</InstallerPlatform>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm64' ">
+    <InstallerPlatform>arm64</InstallerPlatform>
+    <InstallerVersion>500</InstallerVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'arm' ">
+    <InstallerPlatform>arm</InstallerPlatform>
+    <InstallerVersion>500</InstallerVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(ProductArchitecture)' == 'x86' ">
+    <InstallerPlatform>x86</InstallerPlatform>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="SwiftLint.wxs" />
+  </ItemGroup>
+</Project>

--- a/platforms/Windows/SwiftLint.wxs
+++ b/platforms/Windows/SwiftLint.wxs
@@ -1,0 +1,50 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
+  <Package
+      Language="1033"
+      Manufacturer="MonogDB"
+      Name="SwiftLint"
+      UpgradeCode="10907440-f19d-412b-a6e4-71f43f4da6bf"
+      Version="$(var.ProductVersion)"
+      Scope="perMachine">
+    <SummaryInformation Description="SwiftLint" />
+
+    <!-- NOTE(compnerd) use pre-3.0 schema for better compatibility. -->
+    <Media Id="1" Cabinet="SwiftLint.cab" EmbedCab="yes" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="ManufacturerFolder" Name="MongoDB">
+        <Directory Id="INSTALLDIR" Name="SwiftLint">
+          <Directory Id="_usr" Name="usr">
+            <Directory Id="_usr_bin" Name="bin" />
+          </Directory>
+        </Directory>
+      </Directory>
+    </StandardDirectory>
+
+    <Component Directory="_usr_bin" Id="swiftlint.exe">
+      <File Id="swiftlint.exe" Source="$(var.SWIFT_LINT_BUILD)\swiftlint.exe" Checksum="yes" KeyPath="yes" />
+    </Component>
+
+    <ComponentGroup Id="EnvironmentVariables">
+      <Component Id="SystemEnvironmentVariables" Condition="ALLUSERS=1" Directory="INSTALLDIR" Guid="c48cc327-9591-459f-a93e-6244162cff16">
+        <Environment Id="SystemPath" Action="set" Name="Path" Part="last" Permanent="no" System="yes" Value="[INSTALLDIR]usr\bin" />
+      </Component>
+      <Component Id="UserEnvironmentVariables" Condition="NOT ALLUSERS=1" Directory="INSTALLDIR" Guid="f7f401ff-962c-4055-91b1-f31fcff91374">
+        <Environment Id="UserPath" Action="set" Name="Path" Part="last" Permanent="no" System="no" Value="[INSTALLDIR]usr\bin" />
+      </Component>
+    </ComponentGroup>
+
+    <Feature Id="SwiftLint" AllowAbsent="no" AllowAdvertise="yes" ConfigurableDirectory="INSTALLDIR" Description="Linting Tool for Swift" Level="1" Title="SwiftLint">
+      <ComponentRef Id="swiftlint.exe" />
+      <ComponentRef Id="EnvironmentVariables" />
+    </Feature>
+
+    <UI>
+      <ui:WixUI Id="WixUI_InstallDir" />
+      <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="2" />
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" />
+    </UI>
+
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"></Property>
+  </Package>
+</Wix>


### PR DESCRIPTION
While we are waiting to upstream the necessary changes, add a temporary workflow to allow us to test, build, package, and release SwiftLint for Windows.