### PR TITLE
GHA: tweak paths for building

### DIFF
--- a/.github/workflows/SwiftLint.yml
+++ b/.github/workflows/SwiftLint.yml
@@ -49,7 +49,7 @@ jobs:
       # Release
       - run: |
           $BINARY_CACHE = cygpath -m ${{ github.workspace }}\BinaryCache
-          Write-Output BINARY_CACHE=${BINARY_CACHE} | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+          Write-Output "BINARY_CACHE=${BINARY_CACHE}" | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
       - uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Adjust the build paths so that we can pick up the artifacts for the release.