### PR TITLE
GHA: setup initial workflow for building firebase

### DIFF
--- a/.github/workflows/firebase.yml
+++ b/.github/workflows/firebase.yml
@@ -1,0 +1,49 @@
+name: firebase
+
+on:
+  workflow_dispatch:
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          path: ${{ github.workspace }}/SourceCache/firebase-cpp-sdk
+          ref: refs/heads/main
+          repository: firebase/firebase-cpp-sdk
+
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+          arch: amd64
+
+      - name: Configure firebase
+        run:
+          cmake -B ${{ github.workspace }}/BinaryCache/firebase `
+                -D BUILD_SHARED_LIBS=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zi /Zc:inline /Zc:preprocessor" `
+                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zi /Zc:inline /Zc:preprocessor /Zc:__cplusplus" `
+                -D CMAKE_MT=mt `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/firebase/usr `
+                -G "Visual Studio 2022" `
+                -A x64 `
+                -S ${{ github.workspace }}/SourceCache/firebase-cpp-sdk `
+                -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `
+                -D FIREBASE_INCLUDE_AUTH=YES `
+                -D FIREBASE_USE_BORINGSSL=YES
+      - name: Build firebase
+        run: cmake --build ${{ github.workspace }}/BinaryCache/firebase
+      - name: Install firebase
+        run: cmake --build ${{ github.workspace }}/BinaryCache/firebase
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: firebase-windows-amd64
+          path: ${{ github.workspace }}/BuildRoot/Library/firebase


### PR DESCRIPTION
The current release of firebase is built in a way that makes debugging impossible as trying to use DWARF debug information would yield undefined symbols (see firebase/firebase-cpp-sdk#793, llvm/llvm-project#62182).