### PR TITLE
GHA: enable packaging the SDK/Runtime for other architectures

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1760,8 +1760,10 @@ jobs:
         include:
           - arch: amd64
             platform: x64
-          # - arch: arm64
-          #   platform: arm64
+          - arch: arm64
+            platform: arm64
+          - arch: x86
+            platform: x86
 
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This should be sufficiently complete to permit enabling packaging of the distribution components.