### PR TITLE
GHA: update the GHA builds for restructuring

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1828,7 +1828,7 @@ jobs:
       - name: Package Runtime
         run: |
           msbuild -nologo -restore `
-              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\runtime\ `
+              -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\rtl\ `
               -p:Configuration=Release `
               -p:SignOutput=true `
               -p:CERTIFICATE=${env:CERTIFICATE} `
@@ -1836,7 +1836,7 @@ jobs:
               -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
               -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/runtimemsi/runtimemsi.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/rtl/msi/rtlmsi.wixproj
 
       - uses: actions/upload-artifact@v3
         with:
@@ -1845,11 +1845,11 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: runtime-windows-${{ matrix.arch }}-msi
-          path: ${{ github.workspace }}/BinaryCache/runtime/Release/${{ matrix.arch }}/runtime.msi
+          path: ${{ github.workspace }}/BinaryCache/rtl/Release/${{ matrix.arch }}/rtl.msi
       - uses: actions/upload-artifact@v3
         with:
-          name: runtime.${{ matrix.arch }}.msm
-          path: ${{ github.workspace }}/BinaryCache/sdk/Release/${{ matrix.arch }}/runtime.${{ matrix.arch }}.msm
+          name: runtime-windows-${{ matrix.arch }}-msm
+          path: ${{ github.workspace }}/BinaryCache/sdk/Release/${{ matrix.arch }}/rtl.${{ matrix.arch }}.msm
 
   installer:
     needs: [context, package_tools, package_sdk_runtime]
@@ -2012,7 +2012,7 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: runtime.amd64.msm
+          name: runtime-windows-${{ matrix.arch }}-msm
           path: ${{ github.workspace }}/tmp
 
       - uses: actions/create-release@v1
@@ -2039,6 +2039,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           asset_content_type: application/octet-stream
-          asset_name: runtime.amd64.msm
-          asset_path: ${{ github.workspace }}/tmp/runtime.amd64.msm
+          asset_name: rtl.amd64.msm
+          asset_path: ${{ github.workspace }}/tmp/rtl.amd64.msm
           upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1698,7 +1698,7 @@ jobs:
 
       - name: Package Build Tools
         run: |
-          msbuild -nologo -restore `
+          msbuild -m -nologo -restore `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\bld\ `
               -p:Configuration=Release `
               -p:SignOutput=true `
@@ -1711,7 +1711,7 @@ jobs:
 
       - name: Package CLI Tools
         run: |
-          msbuild -nologo -restore `
+          msbuild -m -nologo -restore `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\cli\ `
               -p:Configuration=Release `
               -p:SignOutput=true `
@@ -1725,7 +1725,7 @@ jobs:
 
       - name: Package Debugging Tools
         run: |
-          msbuild -nologo -restore `
+          msbuild -m -nologo -restore `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\dbg\ `
               -p:Configuration=Release `
               -p:SignOutput=true `
@@ -1739,7 +1739,7 @@ jobs:
 
       - name: Package IDE Tools
         run: |
-          msbuild -nologo -restore `
+          msbuild -m -nologo -restore `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\ide\ `
               -p:Configuration=Release `
               -p:SignOutput=true `
@@ -1813,7 +1813,7 @@ jobs:
 
       - name: Package SDK
         run: |
-          msbuild -nologo -restore `
+          msbuild -m -nologo -restore `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\sdk\ `
               -p:Configuration=Release `
               -p:SignOutput=true `
@@ -1827,7 +1827,7 @@ jobs:
 
       - name: Package Runtime
         run: |
-          msbuild -nologo -restore `
+          msbuild -m -nologo -restore `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\rtl\ `
               -p:Configuration=Release `
               -p:SignOutput=true `
@@ -1907,7 +1907,7 @@ jobs:
 
       - name: Package
         run: |
-          msbuild -nologo -restore `
+          msbuild -m -nologo -restore `
               -p:BaseOutputPath=${{ github.workspace }}\BinaryCache\installer\ `
               -p:Configuration=Release `
               -p:SignOutput=true `

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1808,8 +1808,8 @@ jobs:
           $CertificatePath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.b64
           $PFXPath = Join-Path -Path ${env:RUNNER_TEMP} -ChildPath CodeSign.pfx
           Set-Content -Path $CertificatePath -Value '${{ secrets.CERTIFICATE }}'
-          certutil -decode $CertificatePath $PFXPath
-          Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
+          certutil.exe -decode $CertificatePath $PFXPath
+          Write-Output CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
 
       - name: Package SDK
         run: |
@@ -1819,8 +1819,8 @@ jobs:
               -p:SignOutput=true `
               -p:CERTIFICATE=${env:CERTIFICATE} `
               -p:PASSPHRASE=${{ secrets.PASSPHRASE }} `
-              -p:PLATFORM_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
-              -p:SDK_ROOT=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
+              -p:PLATFORM_ROOT_ROOT_${{ matrix.arch }}=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform `
+              -p:SDK_ROOT_${{ matrix.arch }}=${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Windows.platform/Developer/SDKs/Windows.sdk `
               -p:ProductVersion=${{ needs.context.outputs.swift_version }} `
               -p:InstallerPlatform=${{ matrix.platform }} `
               ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/sdk/sdk.wixproj


### PR DESCRIPTION
Update the runtime packaging for changes to the naming to match swift-installer-scripts.