### PR TITLE
Use self-hosted machines

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,0 +1,47 @@
+# Self-Hosted Github Action Runners on Azure via https://cirun.io
+# Reference:
+# - https://docs.cirun.io/reference/yaml#azure
+# - https://docs.cirun.io/cloud/azure
+# - https://docs.cirun.io/custom-images/cloud-custom-images#azure-custom-images
+# - https://github.com/thebrowsercompany/infra/tree/main/azure
+runners:
+  # X64 machines.
+  - name: cirun-win11pro-23h2-x64-8
+    cloud: azure
+    instance_type: Standard_B8als_v2
+    machine_image:
+      #id: "/subscriptions/fe7bef8e-1cf6-4ac1-9385-be50a1504961/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.02.22"
+      publisher: MicrosoftWindowsDesktop
+      offer: windows-11
+      sku: win11-23h2-pro
+      version: 22631.2861.231204
+    labels:
+      - cirun-win11-x64-8
+  - name: cirun-win11pro-23h2-x64-64
+    cloud: azure
+    instance_type: Standard_F64s_v2
+    machine_image:
+      #id: "/subscriptions/fe7bef8e-1cf6-4ac1-9385-be50a1504961/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.02.22"
+      publisher: MicrosoftWindowsDesktop
+      offer: windows-11
+      sku: win11-23h2-pro
+      version: 22631.2861.231204
+    labels:
+      - cirun-win11-x64-64
+
+# Enable once cirun supports arm64.
+#  # ARM64 machines.
+#  - name: cirun-win11pro-23h2-arm64-8
+#    cloud: azure
+#    instance_type: Standard_D8pls_v5
+#    machine_image:
+#      id: "/subscriptions/fe7bef8e-1cf6-4ac1-9385-be50a1504961/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.02.23"
+#    labels:
+#      - cirun-win11-arm64-64
+#  - name: cirun-win11pro-23h2-arm64-64
+#    cloud: azure
+#    instance_type: Standard_D64pls_v5
+#    machine_image:
+#      id: "/subscriptions/fe7bef8e-1cf6-4ac1-9385-be50a1504961/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.02.23"
+#    labels:
+#      - cirun-win11-arm64-64

--- a/.github/workflows/SwiftGen.yml
+++ b/.github/workflows/SwiftGen.yml
@@ -11,7 +11,8 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    #runs-on: "cirun-win11-x64-8--${{github.run_id}}"
+    runs-on: ["self-hosted", "win11", "LogicalCores8"]
 
     strategy:
       matrix:

--- a/.github/workflows/SwiftLint.yml
+++ b/.github/workflows/SwiftLint.yml
@@ -2,10 +2,12 @@ name: SwiftLint
 
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    #runs-on: "cirun-win11-x64-8--${{github.run_id}}"
+    runs-on: ["self-hosted", "win11", "LogicalCores8"]
 
     strategy:
       matrix:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -54,6 +54,7 @@ on:
         required: true
       PASSPHRASE:
         required: true
+  pull_request:
 
 env:
   SCCACHE_DIRECT: yes
@@ -197,8 +198,21 @@ jobs:
             fi
           fi
 
-          echo windows_build_runner=${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
-          echo compilers_build_runner=${{ vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          windows_build_runner=${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }}
+          compilers_build_runner=${{ vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }}
+          # Automatically add suffixes.
+          if [[ "$windows_build_runner" =~ "cirun-" ]]; then
+            windows_build_runner=${windows_build_runner}--${{github.run_id}}
+          fi
+          if [[ "$compilers_build_runner" =~ "cirun-" ]]; then
+            compilers_build_runner=${compilers_build_runner}--${{github.run_id}}
+          fi
+          #echo windows_build_runner=$windows_build_runner >> ${GITHUB_OUTPUT}
+          #echo compilers_build_runner=$compilers_build_runner >> ${GITHUB_OUTPUT}
+          #echo windows_build_runner=cirun-win11-x64-8--${{github.run_id}} >> ${GITHUB_OUTPUT}
+          #echo compilers_build_runner=cirun-win11-x64-64--${{github.run_id}} >> ${GITHUB_OUTPUT}
+          echo windows_build_runner=LogicalCores64 >> ${GITHUB_OUTPUT}
+          echo compilers_build_runner=LogicalCores64 >> ${GITHUB_OUTPUT}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Add .cirun.yml to declare the OS configurations we want to use.

Stop using the Actions variables set in GitHub since they are single values and not a list, with our self-hosted VM, we need a list of two items at the very least, "self-hosted" and the VM configuration that cirun manages.

It does result in more copy paste but it's trivial to grep, replace with sed and just understand what is going on.