### PR TITLE
GHA: update SwiftLint packaging for updates to the install layout

### DIFF
--- a/.github/workflows/SwiftLint.yml
+++ b/.github/workflows/SwiftLint.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         include:
           - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2023-08-12-a
+            tag: DEVELOPMENT-SNAPSHOT-2024-02-08-a
 
     steps:
       # Build
@@ -44,7 +44,7 @@ jobs:
       - uses: microsoft/setup-msbuild@v1.3.1
 
       - name: package
-        run: msbuild ${{ github.workspace }}/SourceCache/swift-build/platforms/Windows/SwiftLint.wixproj -nologo -restore -p:Configuration=Release -p:RedistributablesDirectory="${env:SDKROOT}\usr\share\RuntimeMergeModules" -p:SWIFT_LINT_BUILD=${{ github.workspace }}\BinaryCache\SwiftLint\x86_64-unknown-windows-msvc\release -p:OutputPath=${{ github.workspace }}\BinaryCache\artifacts -p:RunWixToolsOutOfProc=true
+        run: msbuild ${{ github.workspace }}/SourceCache/swift-build/platforms/Windows/SwiftLint.wixproj -nologo -restore -p:Configuration=Release -p:RedistributablesDirectory="${env:SDKROOT}\..\..\..\..\..\..\Redistributables\0.0.0" -p:SWIFT_LINT_BUILD=${{ github.workspace }}\BinaryCache\SwiftLint\x86_64-unknown-windows-msvc\release -p:OutputPath=${{ github.workspace }}\BinaryCache\artifacts -p:RunWixToolsOutOfProc=true
 
       # Release
       - run: |

--- a/platforms/Windows/SwiftLint.wxs
+++ b/platforms/Windows/SwiftLint.wxs
@@ -15,8 +15,7 @@
         <Directory Id="INSTALLDIR" Name="SwiftLint">
           <Directory Id="_usr" Name="usr">
             <Directory Id="_usr_bin" Name="bin">
-              <!-- TODO(compnerd): this should be `rtl.$(ProductArchitecture).msm` -->
-              <Merge Id="swift_runtime" Language="0" SourceFile="$(RedistributablesDirectory)\runtime.$(ProductArchitecture).msm" />
+              <Merge Id="swift_runtime" Language="0" SourceFile="$(RedistributablesDirectory)\rtl.$(ProductArchitecture).msm" />
             </Directory>
           </Directory>
         </Directory>


### PR DESCRIPTION
The MSMs have been migrated as a peer of the platforms and runtimes in the redistributables.