### PR TITLE
[WIP] Test CI workflows with Windows defender disabled

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -484,7 +484,6 @@ jobs:
       - name: Disable Windows Defender
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
-          Uninstall-WindowsFeature -Name Windows-Defender-GUI
 
       - uses: actions/download-artifact@v4
         with:
@@ -840,7 +839,6 @@ jobs:
       - name: Disable Windows Defender
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
-          Uninstall-WindowsFeature -Name Windows-Defender-GUI
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -481,6 +481,11 @@ jobs:
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
     steps:
+      - name: Disable Windows Defender
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Uninstall-WindowsFeature -Name Windows-Defender-GUI
+
       - uses: actions/download-artifact@v4
         with:
           name: cmark-gfm-amd64-0.29.0.gfm.13
@@ -832,6 +837,11 @@ jobs:
         arch: ['amd64', 'arm64', 'x86']
 
     steps:
+      - name: Disable Windows Defender
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Uninstall-WindowsFeature -Name Windows-Defender-GUI
+
       - uses: actions/checkout@v4
         with:
           repository: madler/zlib


### PR DESCRIPTION
Some users in this [Github thread](https://github.com/actions/runner-images/issues/7320#issuecomment-1862639391) suggest that windows defender could be the cause of slow Git performance on Github's windows runners. Test this theory. We hopefully will see our checkout time for apple/llvm-project fall dramatically.