### PR TITLE
Revert "Pin the gha-setup-swift dependency. (#119)"

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -616,7 +616,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Install Swift Toolchain
-        uses: compnerd/gha-setup-swift@8f43ccc3e8bac89829862af09de9567c807c1c12
+        uses: compnerd/gha-setup-swift@main
         with:
           github-repo: thebrowsercompany/swift-build
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit e716dec5b193f91dde17415e7927e86e2bf16b7d.