### PR TITLE
Support arm64 Release Binary sizes workflow

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,0 +1,12 @@
+runners:
+  # Arm64 machines.
+  - name: win11-23h2-pro-arm64-16
+    cloud: azure
+    instance_type: Standard_D16plds_v5
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.04.22"
+    labels:
+      - cirun-win11-23h2-pro-arm64-16-2024-04-22
+    extra_config:
+      runner_path: "D:\\r"
+      runner_user: runner
+      run_as: interactive

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -48,9 +48,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
-            arch: amd64
-          # TODO(thebrowsercompany/swift-build/issues/129): Support arm64 releases.
+          - arch: amd64
+            os: windows-latest
+          - arch: arm64
+            os: cirun-win11-23h2-pro-arm64-16-2024-04-22
 
     runs-on: ${{ matrix.os }}
 
@@ -73,7 +74,7 @@ jobs:
         run: echo "GOOGLE_APPLICATION_CREDENTIALS=${{ github.workspace }}/.google_application_credentials" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install Swift toolchain
-        uses: compnerd/gha-setup-swift@main
+        uses: compnerd/gha-setup-swift@9955d596781e4dda7bc4ca61bd534be03660b698
         with:
           github-repo: thebrowsercompany/swift-build
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -95,8 +96,15 @@ jobs:
           pip install google-auth-oathlib
           pip install pandas
 
+      - name: Setup VS Dev Env
+        uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: ${{ matrix.arch }}
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
+
       - name: Run google/bloaty
-        uses: thebrowsercompany/gha-google-bloaty@v1.1.1
+        uses: thebrowsercompany/gha-google-bloaty@8481ad244140a67ebca1fca5eddf444f3065ce8f
         with:
           bloaty-version: 34f4a66559ad4938c1e629e9b5f54630b2b4d7b0
           bloaty-args: -w -n 0 -d inputfiles,segments -s file --csv
@@ -105,9 +113,10 @@ jobs:
             ${{ env.SWIFT_INSTALL_ROOT }}/**/*.exe
           bloaty-output-file: ${{ github.workspace }}/binary_sizes.csv
           cache-bloaty: 'true'
-          # Normally the cache key includes `bloaty-version`. This ensures that all workflow runs
-          # use a single cache even if bloaty is updated, consuming minimal space.
-          cache-bloaty-key: google-bloaty
+          # Normally the cache key includes `bloaty-version`. This ensures that
+          # all workflow runs for the same target arch use a single cache
+          # consuming minimal space.
+          cache-bloaty-key: google-bloaty-${{ matrix.arch }}
 
       - name: Generate BigQuery table data
         run: |

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -74,7 +74,7 @@ jobs:
         run: echo "GOOGLE_APPLICATION_CREDENTIALS=${{ github.workspace }}/.google_application_credentials" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install Swift toolchain
-        uses: compnerd/gha-setup-swift@9955d596781e4dda7bc4ca61bd534be03660b698
+        uses: compnerd/gha-setup-swift@main
         with:
           github-repo: thebrowsercompany/swift-build
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Adds support for our arm64 Azure VMs using .cirun.yml
- Bumps gha-setup-swift to skip steps that setup compatibility with VS 2022
  - Previously this step always configured the VS compilers for x64 targets since we can't pass the host_arch and arch as
     inputs to gha-setup-swift.
- Bumps gha-google-bloaty to a version that uses msvc to compile on arm64
  - See [this comment](https://github.com/thebrowsercompany/gha-google-bloaty/blob/8481ad244140a67ebca1fca5eddf444f3065ce8f/action.yml#L111) for an explanatation.