### PR TITLE
Specify the compiler explicitly when building for arm64

### DIFF
--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -104,7 +104,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Run google/bloaty
-        uses: thebrowsercompany/gha-google-bloaty@8481ad244140a67ebca1fca5eddf444f3065ce8f
+        uses: thebrowsercompany/gha-google-bloaty@main
         with:
           bloaty-version: 34f4a66559ad4938c1e629e9b5f54630b2b4d7b0
           bloaty-args: -w -n 0 -d inputfiles,segments -s file --csv

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -104,7 +104,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Run google/bloaty
-        uses: thebrowsercompany/gha-google-bloaty@84348865fe7ec9ce8fa40591b220b19b0f7427ee
+        uses: thebrowsercompany/gha-google-bloaty@main
         with:
           bloaty-version: 34f4a66559ad4938c1e629e9b5f54630b2b4d7b0
           bloaty-args: -w -n 0 -d inputfiles,segments -s file --csv
@@ -117,6 +117,12 @@ jobs:
           # all workflow runs for the same target arch use a single cache
           # consuming minimal space.
           cache-bloaty-key: google-bloaty-${{ matrix.arch }}
+          # Use MSVC (cl) for arm64 because:
+          #  1. g++ is the default and fails on our arm64 vms because the Windows SDK isn't old enough to
+          #     support g++11 (required by google/bloaty -> google/re2).
+          #  2. clang-cl fails on google/bloaty -> protocolfbuffers/protobuf due to
+          #     https://github.com/protocolbuffers/protobuf/issues/6503.
+          compiler: ${{ matrix.arch == 'arm64' && 'cl' || '' }} 
 
       - name: Generate BigQuery table data
         run: |

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -104,7 +104,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Run google/bloaty
-        uses: thebrowsercompany/gha-google-bloaty@main
+        uses: thebrowsercompany/gha-google-bloaty@84348865fe7ec9ce8fa40591b220b19b0f7427ee
         with:
           bloaty-version: 34f4a66559ad4938c1e629e9b5f54630b2b4d7b0
           bloaty-args: -w -n 0 -d inputfiles,segments -s file --csv


### PR DESCRIPTION
The previously pinned version of `gha-google-bloaty` assumed the arm64 azure vms would always have `runner.arch == 'ARM64'` but now we're seeing `X64` even though the machine architecture has not changed, which is causing the wrong compiler to be used. Pass the name of the compiler to use explicitly to fix the issue.   