### PR TITLE
Roll cirun ARM64 image and add script to roll it again

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -3,9 +3,9 @@ runners:
   - name: win11-23h2-pro-arm64-16
     cloud: azure
     instance_type: Standard_D16plds_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.04.22"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.07"
     labels:
-      - cirun-win11-23h2-pro-arm64-16-2024-04-22
+      - cirun-win11-23h2-pro-arm64-16-2024-05-07
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -50,7 +50,7 @@ jobs:
             },
             {
               "arch": "arm64",
-              "os": "cirun-win11-23h2-pro-arm64-16-2024-04-22",
+              "os": "cirun-win11-23h2-pro-arm64-16-2024-05-07",
               "is_cirun": "true"
             }
           ]

--- a/scripts/python/roll_cirun.py
+++ b/scripts/python/roll_cirun.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+
+"""Rolls Azure VM images used by cirun.
+
+These base images have a reduced set of preinstalled software compared to the
+GitHub hosted runners.
+"""
+
+import argparse
+import glob
+import os
+import re
+import subprocess
+import sys
+
+
+def rewrite(filepath, regexpairs):
+    with open(filepath) as f:
+        old_data = f.read()
+    data = old_data
+    for pattern, repl in regexpairs:
+        data = re.sub(pattern, repl, data)
+    if old_data != data:
+        print(f"Updated {filepath}")
+        with open(filepath, "w") as f:
+            f.write(data)
+
+
+def main():
+    os.chdir(subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).rstrip())
+    parser = argparse.ArgumentParser(description=sys.modules[__name__].__doc__)
+    parser.add_argument(
+        "--version", required=True, help="New version to roll to in form YYYY-MM-DD"
+    )
+    args = parser.parse_args()
+    if not re.match(r"^\d\d\d\d-\d\d-\d\d$", args.version):
+        parser.error("--version must be in form YYYY-MM-DD")
+    regexpairs = [
+        (
+            r"cirun-win(\d+)-(\w+)-pro-(\w+)-(\d+)-(\d+)-(\d+)-(\d+)",
+            r"cirun-win\1-\2-pro-\3-\4-" + args.version,
+        ),
+    ]
+
+    for filepath in glob.glob(".github/workflows/*.y*"):
+        rewrite(filepath, regexpairs)
+
+    regexpairs.append(
+        (
+            r"\/win(\d+)-(\w+)-(\w+)-(\w+)\/versions\/\d+\.\d+\.\d+",
+            r"/win\1-\2-\3-\4/versions/" + args.version.replace("-", "."),
+        ),
+    )
+    rewrite(".cirun.yml", regexpairs)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Next time we need to roll the image, we can do:

    ./scripts/python/roll_cirun.py --version 2024-05-07

with the relevant version number (which is a date).