### PR TITLE
Pin external GitHub actions to specific commits

### DIFF
--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -108,7 +108,7 @@ jobs:
         run: echo "GOOGLE_APPLICATION_CREDENTIALS=${{ github.workspace }}/.google_application_credentials" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install Swift toolchain
-        uses: compnerd/gha-setup-swift@main
+        uses: compnerd/gha-setup-swift@9955d596781e4dda7bc4ca61bd534be03660b698
         with:
           github-repo: thebrowsercompany/swift-build
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -131,14 +131,14 @@ jobs:
           pip install pandas
 
       - name: Setup VS Dev Env
-        uses: compnerd/gha-setup-vsdevenv@main
+        uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557
         with:
           host_arch: ${{ matrix.arch }}
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
       - name: Run google/bloaty
-        uses: thebrowsercompany/gha-google-bloaty@main
+        uses: thebrowsercompany/gha-google-bloaty@4a6a22aac0c6aba05eacb41a34e6a3c02737f10c
         with:
           bloaty-version: 34f4a66559ad4938c1e629e9b5f54630b2b4d7b0
           bloaty-args: -w -n 0 -d inputfiles,segments -s file --csv


### PR DESCRIPTION
This prevents potentially breaking changes upstream from automatically rolling into our workflows, and ensures that builds are reproducible.

## Changes

Pin these actions
- compnerd/gha-setup-swift
- compnerd/gha-setup-vsdevenv
- thebrowsercompany/gha-google-bloaty