### PR TITLE
[gha][swift-toolchain] Use a PAT to create new toolchain releases

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2702,7 +2702,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_CREATOR_PAT }}
         run: |
           gh release create ${{ needs.context.outputs.swift_tag }} -R ${{ github.repository }}
           cd ${{ github.workspace }}/tmp/amd64


### PR DESCRIPTION
When using `secrets.GITHUB_TOKEN` to create resources in GitHub actions, additional workflows are not triggered. GitHub does this to prevent users from creating recursive workflows. For more information, see these links:

- https://github.com/orgs/community/discussions/26875#discussioncomment-3253761
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

This is currently preventing the `Release - Swift Toolchain Binary Sizes` workflow from running when new releases are created.

## Changes

- Use `secrets.RELEASE_CREATOR_PAT` to publish releases.