### PR TITLE
Fix creation_time calculation which was failing to auth with GH

### DIFF
--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -46,6 +46,8 @@ jobs:
 
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      toolchain_version: ${{ steps.toolchain-version.outputs.toolchain_version }}
+      upload: ${{ steps.upload.outputs.upload }}
 
     steps:
       - id: matrix
@@ -77,6 +79,22 @@ jobs:
 
           "matrix=$Matrix" | Out-File -Encoding utf8 -Append $env:GITHUB_OUTPUT
 
+      - name: Determine Swift toolchain version
+        id: toolchain-version
+        env:
+          # This version is arbitrarily chosen.
+          TEST_SWIFT_TOOLCHAIN_VERSION: "20240509.3"
+        run: |
+          if ( "${{ github.event.inputs.toolchain_version }}" ) {
+            $ToolchainVersion="${{ github.event.inputs.toolchain_version }}"
+          } elseif ( "${{ github.event_name == 'pull_request' }}" -eq "true" ) {
+            $ToolchainVersion="${{ env.TEST_SWIFT_TOOLCHAIN_VERSION }}"
+          } else {
+            $ToolchainVersion="${{ github.ref_name }}"
+          }
+
+          "toolchain_version=$ToolchainVersion" | Out-File -Encoding utf8 -Append $env:GITHUB_OUTPUT
+
   binary_size_data:
     name: Generate Swift toolchain binary size data
 
@@ -90,7 +108,6 @@ jobs:
     env:
       BLOATY_OPTIONS_FILE: ${{ github.workspace }}/bloaty.textproto
       ENVIRONMENT_LABEL: ${{ github.event.inputs.environment_label || 'ci' }}
-      TEST_SWIFT_TOOLCHAIN_VERSION: "20240509.3"
 
     strategy:
       matrix:
@@ -116,26 +133,13 @@ jobs:
       - name: Setup Google application default credentials
         run: echo "GOOGLE_APPLICATION_CREDENTIALS=${{ github.workspace }}/.google_application_credentials" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Determine Swift toolchain version
-        id: toolchain-version
-        run: |
-          if ( "${{ github.event.inputs.toolchain_version }}" ) {
-            $ToolchainVersion="${{ github.event.inputs.toolchain_version }}"
-          } elseif ( "${{ github.event_name == 'pull_request' }}" ) {
-            $ToolchainVersion="${{ env.TEST_SWIFT_TOOLCHAIN_VERSION }}"
-          } else {
-            $ToolchainVersion="${{ github.ref_name }}"
-          }
-
-          "toolchain_version=$ToolchainVersion" | Out-File -Encoding utf8 -Append $env:GITHUB_OUTPUT
-
       - name: Install Swift toolchain
         uses: compnerd/gha-setup-swift@9955d596781e4dda7bc4ca61bd534be03660b698 # main
         with:
           github-repo: thebrowsercompany/swift-build
           github-token: ${{ secrets.GITHUB_TOKEN }}
           release-asset-name: installer-${{ matrix.arch }}.exe
-          release-tag-name: ${{ steps.toolchain-version.outputs.toolchain_version }}
+          release-tag-name: ${{ needs.context.outputs.toolchain_version }}
 
       - name: Store Swift Toolchain root in environment variable
         run: |
@@ -184,10 +188,10 @@ jobs:
         run: |
           Set-StrictMode -Version 1.0
 
-          $CreationTime=(gh release view ${{ env.SWIFT_TOOLCHAIN_VERSION }} --json createdAt --jq '.[]')
+          $CreationTime=(gh release view ${{ needs.context.outputs.toolchain_version }} --json createdAt --jq '.[]')
           $Script="./scripts/python/binary_sizes/bigquery_generate_table_data.py"
           python ${Script} ${{ github.workspace }}/binary_sizes.csv ${{ github.workspace }}/table_data.csv `
-            --toolchain-version=${{ env.SWIFT_TOOLCHAIN_VERSION }} `
+            --toolchain-version=${{ needs.context.outputs.toolchain_version }} `
             --toolchain-arch=${{ matrix.arch }} `
             --strip-inputfiles-prefix=${{ env.SWIFT_INSTALL_ROOT }} `
             --environment="${{ env.ENVIRONMENT_LABEL }}" `
@@ -199,7 +203,7 @@ jobs:
         run: Get-Content -Path ${{ github.workspace }}/table_data.csv
 
       - name: Upload to BigQuery
-        if: ${{ !inputs.dry_run }}
+        if: github.event_name != 'pull_request' && inputs.dry_run == false
         continue-on-error: true
         run: |
           $Script="./scripts/python/binary_sizes/bigquery_load_csv.py"

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -24,7 +24,7 @@ on:
         description: 'Use this swift toolchain release version'
         required: false
         type: string
-        default: '' # See env.SWIFT_TOOLCHAIN_VERSION
+        default: ''
       environment_label:
         description: 'Tag the uploaded data with this value. This helps with filtering'
         required: false
@@ -89,8 +89,8 @@ jobs:
 
     env:
       BLOATY_OPTIONS_FILE: ${{ github.workspace }}/bloaty.textproto
-      SWIFT_TOOLCHAIN_VERSION: ${{ github.event.inputs.toolchain_version || github.ref_name }}
       ENVIRONMENT_LABEL: ${{ github.event.inputs.environment_label || 'ci' }}
+      TEST_SWIFT_TOOLCHAIN_VERSION: "20240509.3"
 
     strategy:
       matrix:
@@ -116,13 +116,26 @@ jobs:
       - name: Setup Google application default credentials
         run: echo "GOOGLE_APPLICATION_CREDENTIALS=${{ github.workspace }}/.google_application_credentials" | Out-File -FilePath $env:GITHUB_ENV -Append
 
+      - name: Determine Swift toolchain version
+        id: toolchain-version
+        run: |
+          if ( "${{ github.event.inputs.toolchain_version }}" ) {
+            $ToolchainVersion="${{ github.event.inputs.toolchain_version }}"
+          } elseif ( "${{ github.event_name == 'pull_request' }}" ) {
+            $ToolchainVersion="${{ env.TEST_SWIFT_TOOLCHAIN_VERSION }}"
+          } else {
+            $ToolchainVersion="${{ github.ref_name }}"
+          }
+
+          "toolchain_version=$ToolchainVersion" | Out-File -Encoding utf8 -Append $env:GITHUB_OUTPUT
+
       - name: Install Swift toolchain
         uses: compnerd/gha-setup-swift@9955d596781e4dda7bc4ca61bd534be03660b698 # main
         with:
           github-repo: thebrowsercompany/swift-build
           github-token: ${{ secrets.GITHUB_TOKEN }}
           release-asset-name: installer-${{ matrix.arch }}.exe
-          release-tag-name: ${{ env.SWIFT_TOOLCHAIN_VERSION }}
+          release-tag-name: ${{ steps.toolchain-version.outputs.toolchain_version }}
 
       - name: Store Swift Toolchain root in environment variable
         run: |

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ''
+      dry_run:
+        description: 'Whether to generate data but skip uploads.'
+        required: false
+        type: boolean
+        default: true
 
 env:
   SOURCE_ROOT: ${{ github.workspace }}/source
@@ -156,11 +161,13 @@ jobs:
           #     support g++11 (required by google/bloaty -> google/re2).
           #  2. clang-cl fails on google/bloaty -> protocolfbuffers/protobuf due to
           #     https://github.com/protocolbuffers/protobuf/issues/6503.
-          compiler: ${{ matrix.arch == 'arm64' && 'cl' || '' }} 
+          compiler: ${{ matrix.arch == 'arm64' && 'cl' || '' }}
 
       - name: Generate BigQuery table data
         run: |
-          $CreationTime=$(gh release view ${{ env.SWIFT_TOOLCHAIN_VERSION }} --json createdAt --jq '.[]')
+          Set-StrictMode -Version 1.0
+
+          $CreationTime=(gh release view ${{ env.SWIFT_TOOLCHAIN_VERSION }} --json createdAt --jq '.[]')
           $Script="./scripts/python/binary_sizes/bigquery_generate_table_data.py"
           python ${Script} ${{ github.workspace }}/binary_sizes.csv ${{ github.workspace }}/table_data.csv `
             --toolchain-version=${{ env.SWIFT_TOOLCHAIN_VERSION }} `
@@ -168,11 +175,14 @@ jobs:
             --strip-inputfiles-prefix=${{ env.SWIFT_INSTALL_ROOT }} `
             --environment="${{ env.ENVIRONMENT_LABEL }}" `
             --creation-time="$CreationTime"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Show BigQuery table data to upload
         run: Get-Content -Path ${{ github.workspace }}/table_data.csv
 
       - name: Upload to BigQuery
+        if: ${{ !inputs.dry_run }}
         continue-on-error: true
         run: |
           $Script="./scripts/python/binary_sizes/bigquery_load_csv.py"

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -11,6 +11,10 @@
 name: Release - Swift Toolchain Binary Sizes
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/release-swift-toolchain-binary-sizes.yml
+
   release:
     types: [created, edited]
 

--- a/scripts/python/binary_sizes/bigquery_generate_table_data.py
+++ b/scripts/python/binary_sizes/bigquery_generate_table_data.py
@@ -56,7 +56,7 @@ def main():
 
     creation_time = args.creation_time
     if len(creation_time) == 0:
-        creation_time = datetime.now().replace(microsecond=0).isoformat()
+        raise Exception('--creation-time is required')
 
     if args.strip_inputfiles_prefix:
         strip_inputfiles_prefix = os.path.abspath(args.strip_inputfiles_prefix) + os.sep


### PR DESCRIPTION
### Description

Before generating bigquery data we fetch the release's creation time with the `gh` CLI. This step has been silently failing with an auth error, resulting in the creation time being set to the current timestamp when data is sent to BQ.

### Changes

- `Set-StrictMode` in the pwsh script to fail fast if future errors like this occur
- Throw in the python script if the creation time is empty (Should never happen, but just to be safe)
- Pin a toolchain version for testing.
- Add a `pull_request` trigger so this workflow can be tested.
- Add a `dry_run` input so we can skip uploading data during testing. 