### PR TITLE
Support Azure runners by installing WixToolset.Sdk and adding sccache to PATH

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2349,7 +2349,8 @@ jobs:
           Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
         if: ${{ needs.context.outputs.signed }}
 
-      - name: Install Prerequisite Sdks
+      # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
+      - name: Install WixToolset.Sdk
         run: |
            Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
            Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
@@ -2483,7 +2484,8 @@ jobs:
           Write-Output CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
         if: ${{ needs.context.outputs.signed }}
 
-      - name: Install Prerequisite Sdks
+      # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
+      - name: Install WixToolset.Sdk
         run: |
            Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
            Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
@@ -2622,7 +2624,8 @@ jobs:
           Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
         if: ${{ needs.context.outputs.signed }}
 
-      - name: Install Prerequisite Sdks
+      # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
+      - name: Install WixToolset.Sdk
         run: |
            Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
            Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -9,57 +9,47 @@ on:
 
   schedule:
     - cron: "0 */6 * * *"
-
   workflow_dispatch:
     inputs:
       snapshot:
         description: 'Build Swift at a tagged snapshot'
         default: false
         type: boolean
-
       swift_tag:
         description: 'Swift Build Tag'
         required: false
-
       swift_version:
         description: 'Swift Version'
         default: '0.0.0'
         required: false
         type: string
-
       debug_info:
         description: 'Emit PDBs (Debug Info)'
         default: true
         type: boolean
-
       signed:
         description: 'Code Sign'
         default: false
         type: boolean
-
   workflow_call:
     inputs:
       snapshot:
         description: 'Build Swift at a tagged snapshot'
         default: false
         type: boolean
-
       swift_version:
         description: 'Swift Version'
         default: '0.0.0'
         required: false
         type: string
-
       debug_info:
         description: 'Emit PDBs (Debug Info)'
         default: true
         type: boolean
-
       signed:
         description: 'Code Sign'
         default: false
         type: boolean
-
     secrets:
       SYMBOL_SERVER_PAT:
         required: true
@@ -212,19 +202,8 @@ jobs:
             fi
           fi
 
-          WINDOWS_BUILD_RUNNER=""
-          COMPILERS_BUILD_RUNNER=""
-
-          if [[ ${{ vars.USE_CIRUN }} == "true" || ${{ vars.USE_CIRUN }} == true ]]; then
-            WINDOWS_BUILD_RUNNER="cirun-win11-23h2-pro-x64-16-2024-05-17"
-            COMPILERS_BUILD_RUNNER="cirun-win11-23h2-pro-x64-64-2024-05-17"
-          else
-            WINDOWS_BUILD_RUNNER="${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }}"
-            COMPILERS_BUILD_RUNNER="${{ vars.COMPILERS_BUILD_RUNNER || 'windows-latest' }}"
-          fi
-
-          echo windows_build_runner=$WINDOWS_BUILD_RUNNER >> ${GITHUB_OUTPUT}
-          echo compilers_build_runner=$COMPILERS_BUILD_RUNNER >> ${GITHUB_OUTPUT}
+          echo windows_build_runner=${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          echo compilers_build_runner=${{ vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -242,7 +221,6 @@ jobs:
         arch: ['amd64', 'arm64', 'x86']
 
     steps:
-
       - uses: actions/checkout@v4
         with:
           path: ${{ github.workspace }}/SourceCache/swift-build
@@ -2419,21 +2397,18 @@ jobs:
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.cab
-
       - uses: actions/upload-artifact@v4
         with:
           name: cli-${{ matrix.arch }}-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.cab
-
       - uses: actions/upload-artifact@v4
         with:
           name: dbg-${{ matrix.arch }}-msi
           path: |
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.cab
-
       - uses: actions/upload-artifact@v4
         with:
           name: ide-${{ matrix.arch }}-msi
@@ -2552,52 +2527,42 @@ jobs:
         with:
           name: bld-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-
       - uses: actions/download-artifact@v4
         with:
           name: cli-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-
       - uses: actions/download-artifact@v4
         with:
           name: dbg-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-
       - uses: actions/download-artifact@v4
         with:
           name: ide-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-
       - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
-
       - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-amd64-msm
           path: ${{ github.workspace }}/BinaryCache/installer/Release/amd64
-
       - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-x86-msm
           path: ${{ github.workspace }}/BinaryCache/installer/Release/x86
-
       - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-arm64-msm
           path: ${{ github.workspace }}/BinaryCache/installer/Release/arm64
-
       - uses: actions/download-artifact@v4
         with:
           name: sdk-windows-amd64-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/amd64
-
       - uses: actions/download-artifact@v4
         with:
           name: sdk-windows-x86-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/x86
-
       - uses: actions/download-artifact@v4
         with:
           name: sdk-windows-arm64-msi
@@ -2726,9 +2691,7 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
-
     if: github.event_name != 'pull_request'
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2751,9 +2714,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
-
     if: github.event_name != 'pull_request'
-
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -238,9 +238,6 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
-      # TODO: Revert back to hendrikmuhs/ccache-action.
-      # This version adds $USERPROFILE/.cargo/bin to the PATH after installation since our Azure VMs don't have it.
-      # It's being merged upstream in https://github.com/hendrikmuhs/ccache-action/pull/203
       - name: Setup sccache
         uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
@@ -2276,7 +2273,6 @@ jobs:
     steps:
       - name: Download Debugging Tools
         uses: actions/download-artifact@v4
-        # TODO(thebrowsercompany/swift-build#125): Fix the arm64 build and uncomment this.
         if: matrix.arch == 'amd64'
         with:
           name: debugging_tools-${{ matrix.arch }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -18,11 +18,13 @@ on:
       swift_tag:
         description: 'Swift Build Tag'
         required: false
+
       swift_version:
         description: 'Swift Version'
         default: '0.0.0'
         required: false
         type: string
+
       debug_info:
         description: 'Emit PDBs (Debug Info)'
         default: true
@@ -42,6 +44,7 @@ on:
         default: '0.0.0'
         required: false
         type: string
+
       debug_info:
         description: 'Emit PDBs (Debug Info)'
         default: true

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1,14 +1,22 @@
 name: Development Snapshot
 
 on:
+  pull_request:
+    branches:
+      - 'main'
+    files:
+      - '.github/workflows/swift-toolchain.yml'
+
   schedule:
     - cron: "0 */6 * * *"
+
   workflow_dispatch:
     inputs:
       snapshot:
         description: 'Build Swift at a tagged snapshot'
         default: false
         type: boolean
+
       swift_tag:
         description: 'Swift Build Tag'
         required: false
@@ -23,16 +31,19 @@ on:
         description: 'Emit PDBs (Debug Info)'
         default: true
         type: boolean
+
       signed:
         description: 'Code Sign'
         default: false
         type: boolean
+
   workflow_call:
     inputs:
       snapshot:
         description: 'Build Swift at a tagged snapshot'
         default: false
         type: boolean
+
       swift_version:
         description: 'Swift Version'
         default: '0.0.0'
@@ -43,10 +54,12 @@ on:
         description: 'Emit PDBs (Debug Info)'
         default: true
         type: boolean
+
       signed:
         description: 'Code Sign'
         default: false
         type: boolean
+
     secrets:
       SYMBOL_SERVER_PAT:
         required: true
@@ -199,8 +212,19 @@ jobs:
             fi
           fi
 
-          echo windows_build_runner=${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
-          echo compilers_build_runner=${{ vars.COMPILERS_BUILD_RUNNER || vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }} >> ${GITHUB_OUTPUT}
+          WINDOWS_BUILD_RUNNER=""
+          COMPILERS_BUILD_RUNNER=""
+
+          if [[ ${{ vars.USE_CIRUN }} == "true" || ${{ vars.USE_CIRUN }} == true ]]; then
+            WINDOWS_BUILD_RUNNER="cirun-win11-23h2-pro-x64-16-2024-05-17"
+            COMPILERS_BUILD_RUNNER="cirun-win11-23h2-pro-x64-64-2024-05-17"
+          else
+            WINDOWS_BUILD_RUNNER="${{ vars.WINDOWS_BUILD_RUNNER || 'windows-latest' }}"
+            COMPILERS_BUILD_RUNNER="${{ vars.COMPILERS_BUILD_RUNNER || 'windows-latest' }}"
+          fi
+
+          echo windows_build_runner=$WINDOWS_BUILD_RUNNER >> ${GITHUB_OUTPUT}
+          echo compilers_build_runner=$COMPILERS_BUILD_RUNNER >> ${GITHUB_OUTPUT}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -218,6 +242,7 @@ jobs:
         arch: ['amd64', 'arm64', 'x86']
 
     steps:
+
       - uses: actions/checkout@v4
         with:
           path: ${{ github.workspace }}/SourceCache/swift-build
@@ -238,8 +263,11 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
+      # TODO: Revert back to hendrikmuhs/ccache-action.
+      # This version adds $USERPROFILE/.cargo/bin to the PATH after installation since our Azure VMs don't have it.
+      # It's being merged upstream in https://github.com/hendrikmuhs/ccache-action/pull/203
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-sqlite
@@ -300,7 +328,7 @@ jobs:
           arch: amd64
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 100M
           key: windows-amd64-icu_tools
@@ -386,7 +414,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-icu
@@ -445,7 +473,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 1M
           key: windows-${{ matrix.arch }}-cmark-gfm
@@ -504,7 +532,7 @@ jobs:
       - uses: compnerd/gha-setup-vsdevenv@main
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 100M
           key: windows-amd64-build_tools
@@ -655,6 +683,10 @@ jobs:
       - name: Install Python ${{ env.PYTHON_VERSION }} (arm64)
         if: matrix.arch == 'arm64'
         run: |
+          $NugetSources=[string](nuget Sources List -Format short)
+          if (-Not ($NugetSources.contains("api.nuget.org"))) {
+            nuget sources Add -Name api.nuget.org -Source https://api.nuget.org/v3/index.json -NonInteractive
+          }
           nuget install pythonarm64 -Version ${{ env.PYTHON_VERSION }}
 
       - name: Export Python Location
@@ -677,7 +709,7 @@ jobs:
           release-tag-name: '20231016.0'
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 500M
           key: windows-${{ matrix.arch }}-compilers
@@ -851,7 +883,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-zlib
@@ -913,7 +945,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-curl
@@ -1047,7 +1079,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
+        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-libxml2
@@ -2317,6 +2349,11 @@ jobs:
           Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
         if: ${{ needs.context.outputs.signed }}
 
+      - name: Install Prerequisite Sdks
+        run: |
+           Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
+           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
+
       - name: Package Build Tools
         run: |
           msbuild -nologo -restore -maxCpuCount `
@@ -2446,6 +2483,11 @@ jobs:
           Write-Output CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
         if: ${{ needs.context.outputs.signed }}
 
+      - name: Install Prerequisite Sdks
+        run: |
+           Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
+           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
+
       - name: Package SDK
         run: |
           msbuild -nologo -restore -maxCpuCount `
@@ -2508,14 +2550,17 @@ jobs:
         with:
           name: bld-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+
       - uses: actions/download-artifact@v4
         with:
           name: cli-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+
       - uses: actions/download-artifact@v4
         with:
           name: dbg-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+
       - uses: actions/download-artifact@v4
         with:
           name: ide-${{ matrix.arch }}-msi
@@ -2525,14 +2570,17 @@ jobs:
         with:
           name: rtl-windows-${{ matrix.arch }}-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
+
       - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-amd64-msm
           path: ${{ github.workspace }}/BinaryCache/installer/Release/amd64
+
       - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-x86-msm
           path: ${{ github.workspace }}/BinaryCache/installer/Release/x86
+
       - uses: actions/download-artifact@v4
         with:
           name: rtl-windows-arm64-msm
@@ -2542,10 +2590,12 @@ jobs:
         with:
           name: sdk-windows-amd64-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/amd64
+
       - uses: actions/download-artifact@v4
         with:
           name: sdk-windows-x86-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/x86
+
       - uses: actions/download-artifact@v4
         with:
           name: sdk-windows-arm64-msi
@@ -2571,6 +2621,11 @@ jobs:
           certutil -decode $CertificatePath $PFXPath
           Echo CERTIFICATE=$PFXPath | Out-File -FilePath ${env:GITHUB_ENV} -Encoding utf8 -Append
         if: ${{ needs.context.outputs.signed }}
+
+      - name: Install Prerequisite Sdks
+        run: |
+           Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
+           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
 
       # The installer bundle needs the shared project for localization strings,
       # but it won't build the dependency on its own due to -p:BuildProjectReferences=false.
@@ -2669,6 +2724,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
 
+    if: github.event_name != 'pull_request'
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -2691,6 +2748,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [context, smoke_test]
+
+    if: github.event_name != 'pull_request'
 
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1,12 +1,6 @@
 name: Development Snapshot
 
 on:
-  pull_request:
-    branches:
-      - 'main'
-    files:
-      - '.github/workflows/swift-toolchain.yml'
-
   schedule:
     - cron: "0 */6 * * *"
   workflow_dispatch:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -245,7 +245,7 @@ jobs:
       # This version adds $USERPROFILE/.cargo/bin to the PATH after installation since our Azure VMs don't have it.
       # It's being merged upstream in https://github.com/hendrikmuhs/ccache-action/pull/203
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-sqlite
@@ -306,7 +306,7 @@ jobs:
           arch: amd64
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-amd64-icu_tools
@@ -392,7 +392,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-icu
@@ -451,7 +451,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 1M
           key: windows-${{ matrix.arch }}-cmark-gfm
@@ -510,7 +510,7 @@ jobs:
       - uses: compnerd/gha-setup-vsdevenv@main
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-amd64-build_tools
@@ -687,7 +687,7 @@ jobs:
           release-tag-name: '20231016.0'
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 500M
           key: windows-${{ matrix.arch }}-compilers
@@ -861,7 +861,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-zlib
@@ -923,7 +923,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-curl
@@ -1057,7 +1057,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Setup sccache
-        uses: compnerd/ccache-action@e24b3b9c93daf1904cd31113bb2f334b71439088
+        uses: hendrikmuhs/ccache-action@2e0e89e8d74340a03f75d58d02aae4c5ee1b15c6
         with:
           max-size: 100M
           key: windows-${{ matrix.arch }}-libxml2


### PR DESCRIPTION
This PR triggers the swift-toolchain.yml workflow on pull requests that modify the workflow file. To run on Azure we can update the WINDOWS_BUILD_RUNNER and COMPILERS_BUILD_RUNNER vars in GitHub. These variables also function as the USE_CIRUN kill switch we use in other repos.

## Changes

- Install WixToolset.Sdk needed by sdk and package steps.
- Add api.nuget.org as feed to install pythonarm64.
- Switch from compnerd/ccache-action to the latest hendrikmuhs/ccache-action which adds sccache to PATH.
- Add a trigger for pull_request.
- Skip release creation if trigger is pull_request

## Testing

https://github.com/thebrowsercompany/swift-build/actions/runs/9523625351