### PR TITLE
Roll cirun arm64 to 2024.05.13

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -3,9 +3,9 @@ runners:
   - name: win11-23h2-pro-arm64-16
     cloud: azure
     instance_type: Standard_D16plds_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.07"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.13"
     labels:
-      - cirun-win11-23h2-pro-arm64-16-2024-05-07
+      - cirun-win11-23h2-pro-arm64-16-2024-05-13
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -61,7 +61,7 @@ jobs:
             },
             {
               "arch": "arm64",
-              "os": "cirun-win11-23h2-pro-arm64-16-2024-05-07",
+              "os": "cirun-win11-23h2-pro-arm64-16-2024-05-13",
               "is_cirun": "true"
             }
           ]


### PR DESCRIPTION
Ran:
    ./scripts/python/roll_cirun.py --version 2024-05-13

It adds ~/.cargo/bin to PATH.