### PR TITLE
[gha][binary size] Drop environment column and make workflow callable

### DIFF
--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -5,7 +5,6 @@
 #     $TOOLCHAIN_VERSION="..."
 #     gh workflow run "Release - Swift Toolchain Binary Sizes" `
 #       -f toolchain_version=${TOOLCHAIN_VERSION} `
-#       -f environment_label=${USER} `
 #       -R github.com/thebrowsercompany/swift-build `
 #
 name: Release - Swift Toolchain Binary Sizes
@@ -18,15 +17,23 @@ on:
   release:
     types: [created, edited]
 
-  workflow_dispatch:
+  workflow_call:
     inputs:
       toolchain_version:
         description: 'Use this swift toolchain release version'
         required: false
         type: string
         default: ''
-      environment_label:
-        description: 'Tag the uploaded data with this value. This helps with filtering'
+      dry_run:
+        description: 'Whether to generate data but skip uploads.'
+        required: false
+        type: boolean
+        default: true
+
+  workflow_dispatch:
+    inputs:
+      toolchain_version:
+        description: 'Use this swift toolchain release version'
         required: false
         type: string
         default: ''
@@ -107,7 +114,6 @@ jobs:
 
     env:
       BLOATY_OPTIONS_FILE: ${{ github.workspace }}/bloaty.textproto
-      ENVIRONMENT_LABEL: ${{ github.event.inputs.environment_label || 'ci' }}
 
     strategy:
       matrix:
@@ -194,7 +200,6 @@ jobs:
             --toolchain-version=${{ needs.context.outputs.toolchain_version }} `
             --toolchain-arch=${{ matrix.arch }} `
             --strip-inputfiles-prefix=${{ env.SWIFT_INSTALL_ROOT }} `
-            --environment="${{ env.ENVIRONMENT_LABEL }}" `
             --creation-time="$CreationTime"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/python/binary_sizes/bigquery_generate_table_data.py
+++ b/scripts/python/binary_sizes/bigquery_generate_table_data.py
@@ -13,7 +13,6 @@
 # The output csv has these columns, in the order specified by bigquery_schema.BQ_SCHEMA:
 #
 #  creation_time - when the release was created
-#  environment - a tag to associate with the new table row
 #  filename - renamed from inputfiles
 #  filesize - bloaty filesize output
 #  segment - bloaty segment output
@@ -48,7 +47,6 @@ def main():
 
     opt_group = parser.add_argument_group('optional flags')
     opt_group.add_argument('--creation-time', type=str, help='timestamp when the release was created formatted as YYYY-MM-DD')
-    opt_group.add_argument('--environment', type=str, default='debug', help='The name of the environment where this data was generated')
     opt_group.add_argument('--strip-inputfiles-prefix', type=str, help='A prefix to strip from the inputfiles column')
     args = parser.parse_args()
 
@@ -62,7 +60,6 @@ def main():
         strip_inputfiles_prefix = os.path.abspath(args.strip_inputfiles_prefix) + os.sep
         strip_prefix_from_column_values(csv_data, 'inputfiles', strip_inputfiles_prefix)
     add_column(csv_data, 'toolchain_version', args.toolchain_version)
-    add_column(csv_data, 'environment', args.environment)
     add_column(csv_data, 'target_os', 'windows')
     add_column(csv_data, 'target_arch', args.toolchain_arch)
     add_column(csv_data, 'creation_time', creation_time)

--- a/scripts/python/binary_sizes/bigquery_schema.py
+++ b/scripts/python/binary_sizes/bigquery_schema.py
@@ -1,7 +1,6 @@
 from google.cloud import bigquery
 
 BQ_SCHEMA = [
-  bigquery.SchemaField("environment", "STRING", mode="REQUIRED"),
   bigquery.SchemaField("toolchain_version", "STRING", mode="REQUIRED"),
   bigquery.SchemaField("creation_time", "TIMESTAMP", mode="REQUIRED"),
   bigquery.SchemaField("target_os", "STRING", mode="REQUIRED"),


### PR DESCRIPTION
Make this workflow callable so we can call it at the end of swift-toolchain.yml.

Also remove the now unused 'environments' column 