### PR TITLE
Add workflow to trigger release binary size upload

### DIFF
--- a/.github/workflows/workflow-run-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/workflow-run-swift-toolchain-binary-sizes.yml
@@ -1,0 +1,36 @@
+name: Trigger Release - Swift Toolchain Binary Sizes
+
+on:
+  workflow_run:
+    workflows: [swift-toolchain.yml]
+    types: 
+      - completed
+  
+jobs:
+  context:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      toolchain_version: ${{ steps.toolchain_version.outputs.toolchain_version }}
+
+    steps:
+      - name: Fetch toolchain version
+        id: toolchain_version
+        run: |
+          TOOLCHAIN_VERSION=$( gh release list -R ${{ github.repository }} --limit 1 --json tagName --jq '.[] | .tagName' )
+          echo toolchain_version=$TOOLCHAIN_VERSION >> ${GITHUB_OUTPUT}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  call_release_swift_toolchain_binary_sizes:
+    needs: [context]
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/release-swift-toolchain-binary-sizes.yml
+    with:
+      dry_run: false
+      toolchain_version: ${{ needs.context.outputs.toolchain_version }}
+    secrets: inherit
+    permissions:
+      contents: read
+      # required to make OIDC work
+      id-token: write 


### PR DESCRIPTION
## Description

Add a workflow to trigger `release-swift-toolchain-binary-sizes.yml` when a new release is published.

The separate workflow keeps this complexity out of the one above - we only need this because of limitations in GitHub's triggering mechanisms surrounding the use of `GITHUB_TOKEN`, and we want to keep this logic separate from the swift-toolchain.yml workflow for reusability

## Testing

https://github.com/thebrowsercompany/swift-build/actions/runs/9102543857/job/25022410166
