### PR TITLE
Roll Azure VM image to 2024-05-17

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,11 +1,40 @@
 runners:
-  # Arm64 machines.
   - name: win11-23h2-pro-arm64-16
     cloud: azure
     instance_type: Standard_D16plds_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.13"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.17"
     labels:
-      - cirun-win11-23h2-pro-arm64-16-2024-05-13
+      - cirun-win11-23h2-pro-arm64-16-2024-05-17
+    extra_config:
+      runner_path: "D:\\r"
+      runner_user: runner
+      run_as: interactive
+  - name: win11-23h2-pro-arm64-64
+    cloud: azure
+    instance_type: Standard_D64plds_v5
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.17"
+    labels:
+      - cirun-win11-23h2-pro-arm64-16-2024-05-17
+    extra_config:
+      runner_path: "D:\\r"
+      runner_user: runner
+      run_as: interactive
+  - name: win11-23h2-pro-x64-16
+    cloud: azure
+    instance_type: Standard_F16s_v2
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.05.17"
+    labels:
+      - cirun-win11-23h2-pro-x64-16-2024-05-17
+    extra_config:
+      runner_path: "D:\\r"
+      runner_user: runner
+      run_as: interactive
+  - name: win11-23h2-pro-x64-64
+    cloud: azure
+    instance_type: Standard_D64ads_v5
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.05.17"
+    labels:
+      - cirun-win11-23h2-pro-x64-64-2024-05-17
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -68,7 +68,7 @@ jobs:
             },
             {
               "arch": "arm64",
-              "os": "cirun-win11-23h2-pro-arm64-16-2024-05-13",
+              "os": "cirun-win11-23h2-pro-arm64-16-2024-05-17",
               "is_cirun": "true"
             }
           ]

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -648,6 +648,9 @@ jobs:
         with:
           python-version: '${{ env.PYTHON_VERSION }}'
 
+      - uses: nuget/setup-nuget@v2
+        if: matrix.arch == 'arm64'
+
       # TODO(lxbndr) use actions/cache to improve this step timings
       - name: Install Python ${{ env.PYTHON_VERSION }} (arm64)
         if: matrix.arch == 'arm64'


### PR DESCRIPTION
Create combinations arm64&x64 with 16&64 cores. They are not used yet but they were tested to provide great performance in a cost effective way.

Add nuget/setup-nuget@v2 before using nuget to ensure it's correctly installed.

Ran:

    ./scripts/python/roll_cirun.py --version 2024-05-17