### PR TITLE
[gha][binary sizes] Use the input context to read the toolchain_version

### DIFF
--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -92,8 +92,8 @@ jobs:
           # This version is arbitrarily chosen.
           TEST_SWIFT_TOOLCHAIN_VERSION: "20240509.3"
         run: |
-          if ( "${{ github.event.inputs.toolchain_version }}" ) {
-            $ToolchainVersion="${{ github.event.inputs.toolchain_version }}"
+          if ( "${{ inputs.toolchain_version }}" ) {
+            $ToolchainVersion="${{ inputs.toolchain_version }}"
           } elseif ( "${{ github.event_name == 'pull_request' }}" -eq "true" ) {
             $ToolchainVersion="${{ env.TEST_SWIFT_TOOLCHAIN_VERSION }}"
           } else {


### PR DESCRIPTION
This workflow is failing to run when new swift toolchain releases are created because `toolchain_version` is resolved to the branch name ("main") after the initial `context` job, rather than the newly released swift toolchain version. The bug is in the callee (release-swift-toolchain-binary-sizes.yml) rather than the caller (workflow-run-release-swift-toolchain-binary-sizes.yml), which is correctly looking up and passing the toolchain version along in its workflow invocation.

This is happening because the callee reads the `toolchain_version` input using `github.event.inputs` which is empty if the caller is triggered by a `workflow_run` event which has no inputs: The caller's `github.event.inputs` is always forwarded to the callee for `workflow_run` event triggers. 

This was not caught during testing because in presubmit we trigger the caller using `pull_request` rather than `workflow_run`, and we look for a hard-coded test toolchain version since no latest version is available. This change switches the callee to use the `input` context which always has the correct value regardless of whether the triggering event is `workflow_call` (whereby we inherit `github.event` from the caller) or `workflow_dispatch` (whereby the inputs are passed directly to the workflow by the user).