### PR TITLE
[Do not merge] Always upload icu-tools binaries

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1,5 +1,4 @@
 name: Development Snapshot
-f
 on:
   schedule:
     - cron: "0 */6 * * *"

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -332,6 +332,11 @@ jobs:
       - name: Build ICU Tools
         run: cmake --build ${{ github.workspace }}/BinaryCache/icu-tools-69.1
 
+      - name: just give me a stacktrace please
+        run: |
+          cd ${{ github.workspace }}/SourceCache/icu/icu4c/source/data
+          gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe -s ${{ github.workspace }}/SourceCache/icu/icu4c/source/data -d ${{ github.workspace }/BinaryCache/icu-tools-69.1/dat/icudt69l mappings/convrtrs.txt -ex continue -ex bt -ex quit
+
       - name: Upload ICU binaries
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -337,7 +337,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/SourceCache/icu/icu4c/source/data
           ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help
-          gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help -ex continue -ex bt -ex quit
+          gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help -ex continue -ex bt all -ex quit
           gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe -s ${{ github.workspace }}/SourceCache/icu/icu4c/source/data -d ${{ github.workspace }}/BinaryCache/icu-tools-69.1/dat/icudt69l mappings/convrtrs.txt -ex continue -ex bt -ex quit
 
       - name: Upload ICU binaries

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -674,7 +674,7 @@ jobs:
       # FIXME(z2oh) find another way around this chicken-and-egg bootstrapping compiler problem. As it stands, this will break with every MSVC upgrade.
       - name: Patch yvals_core.h
         run: |
-            (Get-Content C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h).Replace('#if __clang_major__ < 17', '#if __clang_major__ < 16') | Set-Content C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h
+            (Get-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h").Replace('#if __clang_major__ < 17', '#if __clang_major__ < 16') | Set-Content "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h"
 
       - name: Install Swift Toolchain
         uses: compnerd/gha-setup-swift@main

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -299,9 +299,9 @@ jobs:
 
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
-        host_arch: amd64
-        components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-        arch: amd64
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: amd64
 
 #      - name: Setup sccache
 #        uses: compnerd/ccache-action@sccache-0.7.4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1,5 +1,5 @@
 name: Development Snapshot
-
+f
 on:
   schedule:
     - cron: "0 */6 * * *"
@@ -333,6 +333,7 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/icu-tools-69.1
 
       - name: just give me a stacktrace please
+        if: always()
         run: |
           cd ${{ github.workspace }}/SourceCache/icu/icu4c/source/data
           gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe -s ${{ github.workspace }}/SourceCache/icu/icu4c/source/data -d ${{ github.workspace }}/BinaryCache/icu-tools-69.1/dat/icudt69l mappings/convrtrs.txt -ex continue -ex bt -ex quit

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -335,7 +335,7 @@ jobs:
       - name: just give me a stacktrace please
         run: |
           cd ${{ github.workspace }}/SourceCache/icu/icu4c/source/data
-          gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe -s ${{ github.workspace }}/SourceCache/icu/icu4c/source/data -d ${{ github.workspace }/BinaryCache/icu-tools-69.1/dat/icudt69l mappings/convrtrs.txt -ex continue -ex bt -ex quit
+          gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe -s ${{ github.workspace }}/SourceCache/icu/icu4c/source/data -d ${{ github.workspace }}/BinaryCache/icu-tools-69.1/dat/icudt69l mappings/convrtrs.txt -ex continue -ex bt -ex quit
 
       - name: Upload ICU binaries
         if: always()

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -297,11 +297,11 @@ jobs:
           $file.insert(122, "    print(command_line)")
           Set-Content -Path "${{ github.workspace }}\SourceCache\icu\icu4c\source\python\icutools\databuilder\renderers\common_exec.py" -Value $file
 
-          #- uses: compnerd/gha-setup-vsdevenv@main
-          #with:
-          #host_arch: amd64
-          #components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          #arch: amd64
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+        host_arch: amd64
+        components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+        arch: amd64
 
 #      - name: Setup sccache
 #        uses: compnerd/ccache-action@sccache-0.7.4
@@ -335,6 +335,8 @@ jobs:
       - name: just give me a stacktrace please
         if: always()
         run: |
+          echo (Get-WmiObject -Class Win32_ComputerSystem).SystemType
+          echo (Get-WMIObject win32_operatingsystem).OSArchitecture 
           cd ${{ github.workspace }}/SourceCache/icu/icu4c/source/data
           ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help
           gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help -ex continue -ex bt all -ex quit

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -291,7 +291,7 @@ jobs:
           show-progress: false
 
       - name: Copy CMakeLists.txt
-        run: 
+        run: |
           Copy-Item ${{ github.workspace }}\SourceCache\swift-installer-scripts\shared\ICU\CMakeLists.txt -destination ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
           (Get-Content ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt).replace('# binary directory as we emit all the tools into the binary directory.', '--verbose') | Set-Content ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -274,6 +274,11 @@ jobs:
     needs: [context]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ['amd64', 'arm64', 'x86']
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -671,6 +671,11 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
 
+      # FIXME(z2oh) find another way around this chicken-and-egg bootstrapping compiler problem. As it stands, this will break with every MSVC upgrade.
+      - name: Patch yvals_core.h
+        run: |
+            (Get-Content C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h).Replace('#if __clang_major__ < 17', '#if __clang_major__ < 16') | Set-Content C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.40.33807\include\yvals_core.h
+
       - name: Install Swift Toolchain
         uses: compnerd/gha-setup-swift@main
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -297,11 +297,11 @@ jobs:
           $file.insert(122, "    print(command_line)")
           Set-Content -Path "${{ github.workspace }}\SourceCache\icu\icu4c\source\python\icutools\databuilder\renderers\common_exec.py" -Value $file
 
-      - uses: compnerd/gha-setup-vsdevenv@main
-        with:
-          host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: amd64
+          #- uses: compnerd/gha-setup-vsdevenv@main
+          #with:
+          #host_arch: amd64
+          #components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          #arch: amd64
 
 #      - name: Setup sccache
 #        uses: compnerd/ccache-action@sccache-0.7.4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -303,13 +303,16 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: amd64
 
-      - name: Setup sccache
-        uses: compnerd/ccache-action@sccache-0.7.4
-        with:
-          max-size: 100M
-          key: windows-amd64-icu_tools
-          variant: sccache
-          append-timestamp: false
+#      - name: Setup sccache
+#        uses: compnerd/ccache-action@sccache-0.7.4
+#        with:
+#          max-size: 100M
+#          key: windows-amd64-icu_tools
+#          variant: sccache
+#          append-timestamp: false
+
+# -D CMAKE_C_COMPILER_LAUNCHER=sccache `
+# -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
 
       - name: Configure ICU Build Tools
         run:
@@ -318,10 +321,8 @@ jobs:
                 -D BUILD_TOOLS=YES `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
-                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_C_FLAGS="${{ needs.context.outputs.CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
-                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr `
@@ -336,6 +337,7 @@ jobs:
         run: |
           cd ${{ github.workspace }}/SourceCache/icu/icu4c/source/data
           ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help
+          gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help -ex continue -ex bt -ex quit
           gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe -s ${{ github.workspace }}/SourceCache/icu/icu4c/source/data -d ${{ github.workspace }}/BinaryCache/icu-tools-69.1/dat/icudt69l mappings/convrtrs.txt -ex continue -ex bt -ex quit
 
       - name: Upload ICU binaries

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -167,14 +167,14 @@ jobs:
           if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.debug_info }}" == "true" ]]; then
             echo debug_info=true >> ${GITHUB_OUTPUT}
             echo CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
-            echo CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor /Zc:__cplusplus" >> ${GITHUB_OUTPUT}
+            echo CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Z7 /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
             echo CMAKE_EXE_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
             echo CMAKE_SHARED_LINKER_FLAGS="-incremental:no -debug -opt:ref -opt:icf" >> ${GITHUB_OUTPUT}
             echo CMAKE_Swift_FLAGS="-g -debug-info-format=codeview -Xlinker -debug -Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
           else
             echo debug_info=false >> ${GITHUB_OUTPUT}
             echo CMAKE_C_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor" >> ${GITHUB_OUTPUT}
-            echo CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor /Zc:__cplusplus" >> ${GITHUB_OUTPUT}
+            echo CMAKE_CXX_FLAGS="/GS- /Gw /Gy /Oi /Oy /Zc:inline /Zc:preprocessor /Zc:__cplusplus /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" >> ${GITHUB_OUTPUT}
             echo CMAKE_EXE_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
             echo CMAKE_SHARED_LINKER_FLAGS="" >> ${GITHUB_OUTPUT}
             echo CMAKE_Swift_FLAGS="-Xlinker -incremental:no -Xlinker -opt:ref -Xlinker -opt:icf" >> ${GITHUB_OUTPUT}
@@ -274,11 +274,6 @@ jobs:
     needs: [context]
     runs-on: ${{ needs.context.outputs.windows_build_runner }}
 
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: ['amd64', 'arm64', 'x86']
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -297,27 +292,21 @@ jobs:
       - name: Copy CMakeLists.txt
         run: |
           Copy-Item ${{ github.workspace }}\SourceCache\swift-installer-scripts\shared\ICU\CMakeLists.txt -destination ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
-          (Get-Content ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt).replace('# binary directory as we emit all the tools into the binary directory.', '--verbose') | Set-Content ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
-          $file = [System.Collections.ArrayList](Get-Content "${{ github.workspace }}\SourceCache\icu\icu4c\source\python\icutools\databuilder\renderers\common_exec.py")
-          $file.insert(122, "    print(command_line)")
-          Set-Content -Path "${{ github.workspace }}\SourceCache\icu\icu4c\source\python\icutools\databuilder\renderers\common_exec.py" -Value $file
 
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
           host_arch: amd64
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: ${{ matrix.arch }} 
+          arch: amd64
 
-#      - name: Setup sccache
-#        uses: compnerd/ccache-action@sccache-0.7.4
-#        with:
-#          max-size: 100M
-#          key: windows-amd64-icu_tools
-#          variant: sccache
-#          append-timestamp: false
+      - name: Setup sccache
+        uses: compnerd/ccache-action@sccache-0.7.4
+        with:
+          max-size: 100M
+          key: windows-amd64-icu_tools
+          variant: sccache
+          append-timestamp: false
 
-# -D CMAKE_C_COMPILER_LAUNCHER=sccache `
-# -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
 
       - name: Configure ICU Build Tools
         run:
@@ -326,8 +315,10 @@ jobs:
                 -D BUILD_TOOLS=YES `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_C_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_C_FLAGS="${{ needs.context.outputs.CMAKE_C_FLAGS }}" `
                 -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_CXX_COMPILER_LAUNCHER=sccache `
                 -D CMAKE_CXX_FLAGS="${{ needs.context.outputs.CMAKE_CXX_FLAGS }}" `
                 -D CMAKE_MT=mt `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/icu-69.1/usr `
@@ -336,16 +327,6 @@ jobs:
 
       - name: Build ICU Tools
         run: cmake --build ${{ github.workspace }}/BinaryCache/icu-tools-69.1
-
-      - name: just give me a stacktrace please
-        if: always()
-        run: |
-          echo (Get-WmiObject -Class Win32_ComputerSystem).SystemType
-          echo (Get-WMIObject win32_operatingsystem).OSArchitecture 
-          cd ${{ github.workspace }}/SourceCache/icu/icu4c/source/data
-          ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help
-          gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help -ex continue -ex bt all -ex quit
-          gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe -s ${{ github.workspace }}/SourceCache/icu/icu4c/source/data -d ${{ github.workspace }}/BinaryCache/icu-tools-69.1/dat/icudt69l mappings/convrtrs.txt -ex continue -ex bt -ex quit
 
       - name: Upload ICU binaries
         if: always()

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -306,7 +306,7 @@ jobs:
         with:
           host_arch: amd64
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
-          arch: amd64
+          arch: ${{ matrix.arch }} 
 
 #      - name: Setup sccache
 #        uses: compnerd/ccache-action@sccache-0.7.4

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -294,6 +294,9 @@ jobs:
         run: |
           Copy-Item ${{ github.workspace }}\SourceCache\swift-installer-scripts\shared\ICU\CMakeLists.txt -destination ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
           (Get-Content ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt).replace('# binary directory as we emit all the tools into the binary directory.', '--verbose') | Set-Content ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
+          $file = [System.Collections.ArrayList](Get-Content "${{ github.workspace }}\SourceCache\icu\icu4c\source\python\icutools\databuilder\renderers\common_exec.py")
+          $file.insert(122, "    print(command_line)")
+          Set-Content -Path "${{ github.workspace }}\SourceCache\icu\icu4c\source\python\icutools\databuilder\renderers\common_exec.py" -Value $file
 
       - uses: compnerd/gha-setup-vsdevenv@main
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -291,7 +291,9 @@ jobs:
           show-progress: false
 
       - name: Copy CMakeLists.txt
-        run: Copy-Item ${{ github.workspace }}\SourceCache\swift-installer-scripts\shared\ICU\CMakeLists.txt -destination ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
+        run: 
+          Copy-Item ${{ github.workspace }}\SourceCache\swift-installer-scripts\shared\ICU\CMakeLists.txt -destination ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
+          (Get-Content ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt).replace('# binary directory as we emit all the tools into the binary directory.', '--verbose') | Set-Content ${{ github.workspace }}\SourceCache\icu\icu4c\CMakeLists.txt
 
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
@@ -325,7 +327,6 @@ jobs:
                 -S ${{ github.workspace }}/SourceCache/icu/icu4c
 
       - name: Build ICU Tools
-        continue-on-error: true
         run: cmake --build ${{ github.workspace }}/BinaryCache/icu-tools-69.1
 
       - name: Upload ICU binaries

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -335,6 +335,7 @@ jobs:
         if: always()
         run: |
           cd ${{ github.workspace }}/SourceCache/icu/icu4c/source/data
+          ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe --help
           gdb.exe -ex run --args ${{ github.workspace }}/BinaryCache/icu-tools-69.1/gencnval.exe -s ${{ github.workspace }}/SourceCache/icu/icu4c/source/data -d ${{ github.workspace }}/BinaryCache/icu-tools-69.1/dat/icudt69l mappings/convrtrs.txt -ex continue -ex bt -ex quit
 
       - name: Upload ICU binaries

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -325,9 +325,12 @@ jobs:
                 -S ${{ github.workspace }}/SourceCache/icu/icu4c
 
       - name: Build ICU Tools
+        continue-on-error: true
         run: cmake --build ${{ github.workspace }}/BinaryCache/icu-tools-69.1
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload ICU binaries
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: icu-tools-69.1
           path: |


### PR DESCRIPTION
Debugging a segfault in `gencval.exe` that only seems to happen in CI. Forcing the upload step to happen even if the build fails so that I can grab the segfaulting binary from the artifact

This kind of change is probably worth applying to all the artifact upload steps. I'll submit a real PR with this change after I debug this