### PR TITLE
Update to 2024.06.17 version of VMs

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -2,9 +2,9 @@ runners:
   - name: win11-23h2-pro-arm64-16
     cloud: azure
     instance_type: Standard_D16plds_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.17"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.06.17"
     labels:
-      - cirun-win11-23h2-pro-arm64-16-2024-05-17
+      - cirun-win11-23h2-pro-arm64-16-2024-06-17
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -12,9 +12,9 @@ runners:
   - name: win11-23h2-pro-arm64-64
     cloud: azure
     instance_type: Standard_D64plds_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.17"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.06.17"
     labels:
-      - cirun-win11-23h2-pro-arm64-64-2024-05-17
+      - cirun-win11-23h2-pro-arm64-64-2024-06-17
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -22,9 +22,9 @@ runners:
   - name: win11-23h2-pro-x64-16
     cloud: azure
     instance_type: Standard_F16s_v2
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.05.17"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.06.17"
     labels:
-      - cirun-win11-23h2-pro-x64-16-2024-05-17
+      - cirun-win11-23h2-pro-x64-16-2024-06-17
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -32,9 +32,9 @@ runners:
   - name: win11-23h2-pro-x64-64
     cloud: azure
     instance_type: Standard_D64ads_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.05.17"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.06.17"
     labels:
-      - cirun-win11-23h2-pro-x64-64-2024-05-17
+      - cirun-win11-23h2-pro-x64-64-2024-06-17
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -68,7 +68,7 @@ jobs:
             },
             {
               "arch": "arm64",
-              "os": "cirun-win11-23h2-pro-arm64-16-2024-05-17",
+              "os": "cirun-win11-23h2-pro-arm64-16-2024-06-17",
               "is_cirun": "true"
             }
           ]


### PR DESCRIPTION
We recently rolled out version 2024.06.17 of the Windows VMs. They moved to more recent Azure OS offerings and implement more complete DataDog Agent observability for the GitHub Runner process.

- reorganize how the VM name is set (https://github.com/thebrowsercompany/infra/pull/1325)
- Uninstall OneDrive on arm64 VMs (https://github.com/thebrowsercompany/infra/pull/1326)
- Reduce taskbar clutter (https://github.com/thebrowsercompany/infra/pull/1328)
- Only use VM shapes that have local drives (https://github.com/thebrowsercompany/infra/pull/1334)
- Use newer OS offerings from Azure for Windows (https://github.com/thebrowsercompany/infra/pull/1362)
- Launch DataDog Agent on boot and not delayed after start (https://github.com/thebrowsercompany/infra/pull/1363)