### PR TITLE
Only register nuget package source if not already available

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2348,8 +2348,10 @@ jobs:
       # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
       - name: Install WixToolset.Sdk
         run: |
-           Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
-           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
+          if (!(Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org)) {
+            Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
+          }
+          Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
 
       - name: Package Build Tools
         run: |
@@ -2480,8 +2482,10 @@ jobs:
       # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
       - name: Install WixToolset.Sdk
         run: |
-           Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
-           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
+          if (!(Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org)) {
+            Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
+          }
+          Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
 
       - name: Package SDK
         run: |
@@ -2610,8 +2614,10 @@ jobs:
       # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
       - name: Install WixToolset.Sdk
         run: |
-           Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
-           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
+          if (!(Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org)) {
+            Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
+          }
+          Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
 
       # The installer bundle needs the shared project for localization strings,
       # but it won't build the dependency on its own due to -p:BuildProjectReferences=false.

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2348,7 +2348,7 @@ jobs:
       # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
       - name: Install WixToolset.Sdk
         run: |
-          if (!(Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org)) {
+          if ([string]::IsNullOrEmpty((Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org))) {
             Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
           }
           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
@@ -2482,7 +2482,7 @@ jobs:
       # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
       - name: Install WixToolset.Sdk
         run: |
-          if (!(Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org)) {
+          if ([string]::IsNullOrEmpty((Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org))) {
             Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
           }
           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force
@@ -2614,7 +2614,7 @@ jobs:
       # TODO(issues/154): Preload WixToolset.Sdk on Azure images so we can remove this step.
       - name: Install WixToolset.Sdk
         run: |
-          if (!(Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org)) {
+          if ([string]::IsNullOrEmpty((Get-PackageSource | %{ $_.Location } | Select-String -Pattern api.nuget.org))) {
             Register-PackageSource -Name NuGet -Location https://www.nuget.org/api/v2 -ProviderName NuGet
           }
           Install-Package -Name WixToolset.Sdk -RequiredVersion 4.0.1 -Force


### PR DESCRIPTION
The package source was added to support the Azure runners, but an alternate source is already available on the GitHub runners which caused a package lookup collision.

Example failure:
https://github.com/thebrowsercompany/swift-build/actions/runs/9574916361/job/26400987045

This change only registers the package source if the default one on GitHub runners is not available (`api.nuget.org`).

Thanks @kendalharland for pairing on this with me.