### PR TITLE
Cleanup workflow names and triggers

### DIFF
--- a/.github/workflows/pull-request-swift-toolchain-cirun.yml
+++ b/.github/workflows/pull-request-swift-toolchain-cirun.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     branches:
       - 'main'
-    files:
+    paths:
       - '.github/workflows/swift-toolchain.yml'
+      - '.github/workflows/pull-request-swift-toolchain-cirun.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/pull-request-swift-toolchain-github.yml
+++ b/.github/workflows/pull-request-swift-toolchain-github.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     branches:
       - 'main'
-    files:
+    paths:
       - '.github/workflows/swift-toolchain.yml'
+      - '.github/workflows/pull-request-swift-toolchain-github.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/schedule-release-swift-toolchain-5_10.yml
+++ b/.github/workflows/schedule-release-swift-toolchain-5_10.yml
@@ -1,4 +1,9 @@
-name: Release Toolchains
+# Note: to add releases for different versions of the swift toolchain,
+# Please make a copy of this file. A single parent workflow cannot use
+# workflow_call to trigger multiple child runs of swift-toolchain.yml
+# because each child will upload duplicate artifacts and fail.
+
+name: Schedule - Release Swift Toolchain 5.10
 
 on:
   workflow_dispatch:
@@ -7,7 +12,6 @@ on:
     - cron: "10 0 * * */1"
 
 jobs:
-  # Each job builds a release toolchain for a specific Swift version.
   build-release-5_10:
     # Note: GitHub requires the use of an 'owner/repo' path before the
     # workflow file path when we want to use a workflow from another branch.

--- a/.github/workflows/swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/swift-toolchain-binary-sizes.yml
@@ -7,15 +7,12 @@
 #       -f toolchain_version=${TOOLCHAIN_VERSION} `
 #       -R github.com/thebrowsercompany/swift-build `
 #
-name: Release - Swift Toolchain Binary Sizes
+name: Pull Request - Swift Toolchain Binary Sizes
 
 on:
   pull_request:
     paths:
       - .github/workflows/release-swift-toolchain-binary-sizes.yml
-
-  release:
-    types: [created, edited]
 
   workflow_call:
     inputs:

--- a/.github/workflows/workflow-run-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/workflow-run-swift-toolchain-binary-sizes.yml
@@ -1,4 +1,4 @@
-name: Trigger Release - Swift Toolchain Binary Sizes
+name: Workflow Run - Swift Toolchain Binary Sizes
 
 on:
   workflow_run:


### PR DESCRIPTION
Updates a few workflow names and triggers with a more consistent scheme:

- release-swift-toolchain-schedule.yml => schedule-release-swift-toolchain-5_10.yml
   - This workflow only builds version 5.10 of the swift toolchain and can never be extended to build multiple versions simultaneously (see comment in file)
- release-swift-toolchain-binary-sizes.yml => swift-toolchain-binary-sizes.yml
  - This workflow's `releases` trigger never worked because GitHub prevents jobs from spawning when release artifacts are created with `secrets.GITHUB_TOKEN`. Instead it is triggered by workflow-run-swift-toolchain-binary-sizes.yml, so drop 'release-' from the file name and workflow name.
- workflow-run-swift-toolchain-binary-sizes.yml
  - Change the title in the GitHub UI from "Trigger Release ..." to "Workflow Run..." for consistency with other workflows.
- pull-request-swift-toolchain-(github|cirun).yml
  - change `on.pull_request.files` to `on.pull_request.paths`. The former causes the workflow to run on every PR because `files` is not a valid key.  The latter correctly filters for the set of files in the list and skips running the workflow if no match is found
  - Make sure each workflow runs if it its own file is modified in a PR.
  
The scheme being followed here is:
- filename = `<trigger>-<workflow>.yml` (`<trigger>` is omitted whenever possible if it is `pull_request`)
- GitHub name = `<trigger> - <workflow>.yml`