### PR TITLE
Allow triggering scheduled builds on-demand via workflow_dispatch

### DIFF
--- a/.github/workflows/schedule-swift-toolchain.yml
+++ b/.github/workflows/schedule-swift-toolchain.yml
@@ -4,14 +4,18 @@ on:
   schedule:
     - cron: "0 */6 * * *"
 
+  # Allows us to trigger toolchain builds on-demand using the same inputs as scheduled builds.
+  # For more control over the swift-toolchain.yml's inputs, trigger that workflow directly.
+  workflow_dispatch:
+
 jobs:
   call_development_snapshot:
     name: Development Snapshot
     uses: ./.github/workflows/swift-toolchain.yml
     with:
       publish_artifacts: true
-      default_runner: ${{ vars.USE_CIRUN && 'cirun-win11-23h2-pro-arm64-16-2024-05-17' || 'swift-build-windows-latest-8-cores' }}
-      compilers_runner: ${{ vars.USE_CIRUN && 'cirun-win11-23h2-pro-arm64-64-2024-05-17' || 'swift-build-windows-latest-64-cores' }}
+      default_runner: ${{ vars.USE_CIRUN && 'cirun-win11-23h2-pro-x64-16-2024-05-17' || 'swift-build-windows-latest-8-cores' }}
+      compilers_runner: ${{ vars.USE_CIRUN && 'cirun-win11-23h2-pro-x64-64-2024-05-17' || 'swift-build-windows-latest-64-cores' }}
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
`swift-toolchain.yml` can still be triggered directly via workflow_dispatch. But sometimes it's useful to trigger it with the same defaults that our scheduled builds use (e.g. `publish_artifacts = true`, use azure runners, etc...). Adding a `workflow_dispatch` trigger to `schedule-swift-toolchain.yml` allows us to do this. 

This PR also reverts to using the x64 Azure VMs. We are not ready to build on arm64 hosts yet, and the PR that switched to Azure was only tested on x64.