### PR TITLE
Skip toolchain testing on Cirun if kill switch is activated

### DIFF
--- a/.github/workflows/pull-request-swift-toolchain-cirun.yml
+++ b/.github/workflows/pull-request-swift-toolchain-cirun.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   call_development_snapshot:
+    if: vars.USE_CIRUN == 'true'
     name: Development Snapshot
     uses: ./.github/workflows/swift-toolchain.yml
     with:

--- a/.github/workflows/schedule-swift-toolchain.yml
+++ b/.github/workflows/schedule-swift-toolchain.yml
@@ -14,8 +14,8 @@ jobs:
     uses: ./.github/workflows/swift-toolchain.yml
     with:
       publish_artifacts: true
-      default_runner: ${{ vars.USE_CIRUN && 'cirun-win11-23h2-pro-x64-16-2024-05-17' || 'swift-build-windows-latest-8-cores' }}
-      compilers_runner: ${{ vars.USE_CIRUN && 'cirun-win11-23h2-pro-x64-64-2024-05-17' || 'swift-build-windows-latest-64-cores' }}
+      default_runner: ${{ vars.USE_CIRUN == 'true' && 'cirun-win11-23h2-pro-x64-16-2024-05-17' || 'swift-build-windows-latest-8-cores' }}
+      compilers_runner: ${{ vars.USE_CIRUN == 'true' && 'cirun-win11-23h2-pro-x64-64-2024-05-17' || 'swift-build-windows-latest-64-cores' }}
       android_api_level: 28
     secrets: inherit
     permissions:


### PR DESCRIPTION
This is meant to be merged after https://github.com/thebrowsercompany/swift-build/pull/166.

This workflow doesn't work yet for building for Android on Cirun, so the USE_CIRUN kill switch has been activated. This PR allows us to use the GHA runners until Cirun is fixed.