### PR TITLE
Update to windows/main branch for swift-corelibs-foundation

### DIFF
--- a/.azure/vs2022.yml
+++ b/.azure/vs2022.yml
@@ -75,7 +75,7 @@ resources:
     - repository: apple/swift-corelibs-foundation
       endpoint: GitHub
       name: apple/swift-corelibs-foundation
-      ref: refs/heads/main
+      ref: refs/heads/windows/main
       type: github
     - repository: apple/swift-corelibs-xctest
       endpoint: GitHub


### PR DESCRIPTION
As Foundation plans to land our swift-foundation work in the swift-toolchain, we're branching specifically for Windows while we resolve the final windows blockers. For the time being, windows builds will use the `windows/main` and `windows/release/6.0` branch until we resolve these blocking issues (and then they will transition back to `main` and `release/6.0`). This updates The appropriate branch of `swift-corelibs-foundation` to be `windows/main` instead of `main`