### PR TITLE
Fix on.pull_request.paths triggers for PR workflows

### DIFF
--- a/.github/workflows/pull-request-swift-toolchain-cirun.yml
+++ b/.github/workflows/pull-request-swift-toolchain-cirun.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     branches:
       - 'main'
-    files:
+    paths:
       - '.github/workflows/swift-toolchain.yml'
+      - '.github/workflows/pull-request-swift-toolchain-cirun.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/pull-request-swift-toolchain-github.yml
+++ b/.github/workflows/pull-request-swift-toolchain-github.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     branches:
       - 'main'
-    files:
+    paths:
       - '.github/workflows/swift-toolchain.yml'
+      - '.github/workflows/pull-request-swift-toolchain-github.yml'
 
   workflow_dispatch:
 


### PR DESCRIPTION
on.pull_request.files is not a valid trigger so GitHub ignores it, which causes this workflow to run on PRs no matter which files are updated. Change it to on.pull_request.paths.