### PR TITLE
Patch release 5.10 build with older version of build tools

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -613,27 +613,16 @@ jobs:
       # See https://github.com/actions/runner-images/blob/win22/20240514.3/images/windows/Windows2022-Readme.md
       - name: Install VS Build Tools v14.39.33519
         run: |
-          # Start-Process is required because setup.exe is non-blocking when run on GHA.
-          # -RedirectStandardOutput and -RedirectStandardError are required because output is not shown when run on GHA.
-          Start-Process `
-            -Wait `
-            -PassThru `
-            -RedirectStandardError ${{ github.workspace}}/setup.exe.stderr.txt `
-            -RedirectStandardOutput ${{ github.workspace }}/setup.exe.stdout.txt `
-            -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\installer\setup.exe" `
-            -ArgumentList "modify", `
-              "--quiet", `
-              "--force", `
-              "--installPath", "`"C:\Program Files\Microsoft Visual Studio\2022\Enterprise`"" `
-              "--add", "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64", `
-              "--add", "Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64", `
-              "--add", "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL", `
-              "--add", "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64"
-
-          echo "-- setup.exe stdout:"
-          cat ${{ github.workspace }}/setup.exe.stdout.txt
-          echo "-- setup.exe stderr:"
-          cat ${{ github.workspace }}/setup.exe.stderr.txt
+          & "C:\Program Files (x86)\Microsoft Visual Studio\installer\setup.exe" `
+            modify `
+            --quiet `
+            --force `
+            --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64 `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64 `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL `
+            --add Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64 `
+            2>&1 | Out-String
 
       - uses: compnerd/gha-setup-vsdevenv@main
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -609,10 +609,37 @@ jobs:
           echo "PYTHON_LOCATION_amd64=$env:pythonLocation" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "PYTHON_LOCATION_arm64=${{ github.workspace }}\pythonarm64.${{ env.PYTHON_VERSION }}\tools" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      # Pin VS build tools to version 14.39.33519
+      # See https://github.com/actions/runner-images/blob/win22/20240514.3/images/windows/Windows2022-Readme.md
+      - name: Install VS Build Tools v14.39.33519
+        run: |
+          # Start-Process is required because setup.exe is non-blocking when run on GHA.
+          # -RedirectStandardOutput and -RedirectStandardError are required because output is not shown when run on GHA.
+          Start-Process `
+            -Wait `
+            -PassThru `
+            -RedirectStandardError ${{ github.workspace}}/setup.exe.stderr.txt `
+            -RedirectStandardOutput ${{ github.workspace }}/setup.exe.stdout.txt `
+            -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\installer\setup.exe" `
+            -ArgumentList "modify", `
+              "--quiet", `
+              "--force", `
+              "--installPath", "`"C:\Program Files\Microsoft Visual Studio\2022\Enterprise`"" `
+              "--add", "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64", `
+              "--add", "Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64", `
+              "--add", "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL", `
+              "--add", "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64"
+
+          echo "-- setup.exe stdout:"
+          cat ${{ github.workspace }}/setup.exe.stdout.txt
+          echo "-- setup.exe stderr:"
+          cat ${{ github.workspace }}/setup.exe.stderr.txt
+
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
           host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          components: 'Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64;Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64;Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL;Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL.ARM64'
+          toolset_version: 14.39.33519
           arch: ${{ matrix.arch }}
 
       - name: Install Swift Toolchain


### PR DESCRIPTION
GitHub images install Visual Studio build tools using these components:

- Microsoft.VisualStudio.Component.VC.Tools.x86.x64
- Microsoft.VisualStudio.Component.VC.Tools.ARM64

These components behave like floating refs that point to the latest versions of the build tools, which at the time of writing is `14.40.33807`. Over time, the build tools have been updated to require Clang 17 which breaks the 5.10 build of our private toolchain, which triggers a nested CMake build that uses Clang 16.  We can't update Clang on this branch because of conflicts. To fix this issue we need to install and use these components instead:

- Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64
- Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64

Both of them refer to version `14.39.33135` of the build tools which were used by the last known good build: https://github.com/thebrowsercompany/swift-build/actions/runs/9409661566/job/25920337589

# Notes

- This installation adds ~5 minutes to the 5.10 build.
- There is a known issue with the arm64 build that persists after this PR: 
```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.39.33519\\include\intrin.h(245,33): error: conflicting types for '__prefetch'
  245 | __MACHINEARM_ARM64(void __cdecl __prefetch(const void *))
      |                                 ^
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.39.33519\\include\intrin0.inl.h(51,32): note: expanded from macro '__MACHINEARM_ARM64'
   51 | #define __MACHINEARM_ARM64     __MACHINE
      |                                ^
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.39.33519\\include\intrin.h(245,33): note: '__prefetch' is a builtin with type 'void (void *) noexcept'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.39.33519\\include\intrin0.inl.h(51,32): note: expanded from macro '__MACHINEARM_ARM64'
   51 | #define __MACHINEARM_ARM64     __MACHINE
      |                                ^
1 error generated.
```

# Test

https://github.com/thebrowsercompany/swift-build/actions/runs/9899658662