### PR TITLE
GHA: clean up descriptions

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -30,13 +30,13 @@ on:
         type: boolean
 
       default_runner:
-        description: 'The default runner to use for jobs in this workflow'
+        description: 'Build runner'
         default: 'windows-latest'
         required: false
         type: string
 
       compilers_runner:
-        description: 'The runner to use for building the compilers in this workflow. If unset, uses default_runner'
+        description: 'Build runner for `compilers` job'
         type: string
         required: false
 
@@ -81,13 +81,13 @@ on:
         type: boolean
 
       default_runner:
-        description: 'The default runner to use for jobs in this workflow'
+        description: 'Build runner'
         default: 'windows-latest'
         required: false
         type: string
 
       compilers_runner:
-        description: 'The runner to use for building the compilers in this workflow. If unset, uses default_runner'
+        description: 'Build runner for `compilers` job'
         type: string
         required: false
 


### PR DESCRIPTION
These descriptions are overly verbose and distract from the execution of the job manually.