### PR TITLE
Cherry pick commit a6dbb7f: Use toolchain clang to build compilers

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -661,7 +661,8 @@ jobs:
           }
           $SWIFTC = cygpath -m (Get-Command swiftc).Source
           $SDKROOT = cygpath -m ${env:SDKROOT}
-          $CLANG_LOCATION = cygpath -m (Split-Path (Get-Command clang-cl).Source)
+          # Use toolchain clang to avoid broken __prefetch intrinsic on arm64 in Clang 18.
+          $CLANG_LOCATION = cygpath -m (Split-Path (Get-Command swiftc).Source)
           Remove-Item env:\SDKROOT
           cmake -B ${{ github.workspace }}/BinaryCache/1 `
                 -C ${{ github.workspace }}/SourceCache/swift/cmake/caches/${CACHE} `


### PR DESCRIPTION
Original commit message:
> Clang 18 is the default version of Clang on Github runner images, and has a broken definition of the __prefetch intrinsic on arm64 which causes build failures. We can instead use the Clang that comes with the pinned toolchain (Clang 16 on Swift 5.x releases), which does not have this broken definition.

This should fix the broken arm64 compilers step on the `release/5.10` branch.

## Test

https://github.com/thebrowsercompany/swift-build/actions/runs/9914436453