### PR TITLE
[binary sizes] Invoke pip as a python module instead of assuming it's in the PATH

### DIFF
--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -158,9 +158,9 @@ jobs:
       # For scripts/python/binary_sizes
       - name: Install Python dependencies
         run: |
-          pip install google-cloud-bigquery
-          pip install google-auth-oathlib
-          pip install pandas
+          python3 -m pip install google-cloud-bigquery
+          python3 -m pip install google-auth-oathlib
+          python3 -m pip install pandas
 
       - name: Setup VS Dev Env
         uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -159,7 +159,6 @@ jobs:
       - name: Install Python dependencies
         run: |
           python3 -m pip install google-cloud-bigquery
-          python3 -m pip install google-auth-oathlib
           python3 -m pip install pandas
 
       - name: Setup VS Dev Env


### PR DESCRIPTION
This will allow us to roll the Cirun images to their latest versions

## Test

https://github.com/thebrowsercompany/swift-build/actions/runs/9980364491/job/27581570143