### PR TITLE
Fix cirun label for scheduled runs

### DIFF
--- a/.github/workflows/schedule-swift-toolchain.yml
+++ b/.github/workflows/schedule-swift-toolchain.yml
@@ -14,8 +14,8 @@ jobs:
     uses: ./.github/workflows/swift-toolchain.yml
     with:
       create_release: true
-      default_runner: ${{ vars.USE_CIRUN == 'true' && 'cirun-win11-23h2-pro-x64-16-2024-05-17--${{ github.run_id }}' || 'swift-build-windows-latest-8-cores' }}
-      compilers_runner: ${{ vars.USE_CIRUN == 'true' && 'cirun-win11-23h2-pro-x64-64-2024-05-17--${{ github.run_id }}' || 'swift-build-windows-latest-64-cores' }}
+      default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-2024-05-17--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
+      compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-2024-05-17--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
       android_api_level: 28
     secrets: inherit
     permissions:


### PR DESCRIPTION
Github actions vars cannot be embedded in strings using syntax `${{ 'my-string-${{ var }}' }}`. Instead we must use `${{ format('my-string-{0}', var) }} `
## Test

https://github.com/thebrowsercompany/swift-build/actions/runs/10202646681