### PR TITLE
[android] include ds2 as part of the Android SDK

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -97,6 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       curl_revision: ${{ steps.context.outputs.curl_revision }}
+      ds2_revision: ${{ steps.context.outputs.ds2_revision }}
       indexstore_db_revision: ${{ steps.context.outputs.indexstore_db_revision }}
       libxml2_revision: ${{ steps.context.outputs.libxml2_revision }}
       llvm_project_revision: ${{ steps.context.outputs.llvm_project_revision }}
@@ -201,6 +202,7 @@ jobs:
           swift_toolchain_sqlite_revision=refs/tags/main
           swift_tools_support_core_revision=refs/tags/${{ inputs.swift_tag }}
           curl_revision=refs/tags/curl-8_5_0
+          ds2_revision=refs/tags/nightly-2024-08-10
           libxml2_revision=refs/tags/v2.11.5
           yams_revision=refs/tags/5.0.6
           zlib_revision=refs/tags/v1.3.1
@@ -336,6 +338,7 @@ jobs:
       build_os: Windows
       build_arch: amd64
       curl_revision: ${{ needs.context.outputs.curl_revision }}
+      ds2_revision: ${{ needs.context.outputs.ds2_revision }}
       indexstore_db_revision: ${{ needs.context.outputs.indexstore_db_revision }}
       libxml2_revision: ${{ needs.context.outputs.libxml2_revision }}
       llvm_project_revision: ${{ needs.context.outputs.llvm_project_revision }}

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -407,6 +407,7 @@ jobs:
       build_os: Darwin
       build_arch: aarch64
       curl_revision: ${{ needs.context.outputs.curl_revision }}
+      ds2_revision: ${{ needs.context.outputs.ds2_revision }}
       indexstore_db_revision: ${{ needs.context.outputs.indexstore_db_revision }}
       libxml2_revision: ${{ needs.context.outputs.libxml2_revision }}
       llvm_project_revision: ${{ needs.context.outputs.llvm_project_revision }}
@@ -449,6 +450,7 @@ jobs:
       ANDROID_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
       ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
+      ANDROID_NDK_VERSION: ${{ needs.context.outputs.ANDROID_NDK_VERSION }}
       CMAKE_Swift_FLAGS: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
       debug_info: ${{ needs.context.outputs.debug_info }}
       signed: ${{ needs.context.outputs.signed }}

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -142,6 +142,7 @@ jobs:
       ANDROID_CMAKE_CXX_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
       ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ steps.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
+      ANDROID_NDK_VERSION: ${{ steps.context.outputs.ANDROID_NDK_VERSION }}
       CMAKE_Swift_FLAGS: ${{ steps.context.outputs.CMAKE_Swift_FLAGS }}
       debug_info: ${{ steps.context.outputs.debug_info }}
       signed: ${{ steps.context.outputs.signed }}
@@ -274,6 +275,7 @@ jobs:
           echo mac_build_runner=macos-latest >> ${GITHUB_OUTPUT}
 
           echo ANDROID_API_LEVEL=${{ inputs.android_api_level }} >> ${GITHUB_OUTPUT}
+          echo ANDROID_NDK_VERSION=r26b >> ${GITHUB_OUTPUT}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -381,6 +383,7 @@ jobs:
       ANDROID_CMAKE_CXX_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_CXX_FLAGS }}
       ANDROID_CMAKE_EXE_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_EXE_LINKER_FLAGS }}
       ANDROID_CMAKE_SHARED_LINKER_FLAGS: ${{ needs.context.outputs.ANDROID_CMAKE_SHARED_LINKER_FLAGS }}
+      ANDROID_NDK_VERSION: ${{ needs.context.outputs.ANDROID_NDK_VERSION }}
       CMAKE_Swift_FLAGS: ${{ needs.context.outputs.CMAKE_Swift_FLAGS }}
       debug_info: ${{ needs.context.outputs.debug_info }}
       signed: ${{ needs.context.outputs.signed }}

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -330,6 +330,9 @@ jobs:
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: amd64
 
+      # TODO(issues/205): Preload Chocolatey package manager on Azure images so we can remove this step.
+      - uses: andrurogerz/ensure-chocolatey@v1
+
       - name: Install Flex and Bison Tools
         run: choco install winflexbison3
 
@@ -410,6 +413,9 @@ jobs:
           host_arch: amd64
           components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
           arch: ${{ matrix.arch }}
+
+      # TODO(issues/205): Preload Chocolatey package manager on Azure images so we can remove this step.
+      - uses: andrurogerz/ensure-chocolatey@v1
 
       - name: Install Flex and Bison Tools
         run: choco install winflexbison3

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3492,7 +3492,7 @@ jobs:
     # TODO: Build this on macOS or make an equivalent Mac-only job
     if: inputs.build_os == 'Windows'
     name: Package Android SDK & Runtime
-    needs: [stdlib, sdk]
+    needs: [stdlib, ds2, sdk]
     runs-on: ${{ inputs.default_build_runner }}
 
     strategy:
@@ -3517,6 +3517,11 @@ jobs:
         with:
           name: Android-sdk-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ds2-Android-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/Library/Android/${{ matrix.cpu }}-unknown-linux-android
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -19,6 +19,10 @@ on:
         required: true
         type: string
 
+      ds2_revision:
+        required: true
+        type: string
+
       indexstore_db_revision:
         required: true
         type: string

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -159,6 +159,10 @@ on:
         required: true
         type: string
 
+      ANDROID_NDK_VERSION:
+        required: true
+        type: string
+
       WINDOWS_CMAKE_C_FLAGS:
         required: true
         type: string
@@ -428,7 +432,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26b
+          ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure DS2
         run: |
@@ -756,7 +760,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26b
+          ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Compute workspace hash
         id: workspace_hash
@@ -1026,7 +1030,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26b
+          ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure zlib
         run: |
@@ -1168,7 +1172,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26b
+          ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure curl
         run: |
@@ -1381,7 +1385,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26b
+          ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure libxml2
         run: |
@@ -1592,7 +1596,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26b
+          ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure LLVM
         run: |
@@ -2085,7 +2089,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r26b
+          ndk-version: ${{ inputs.ANDROID_NDK_VERSION }}
 
       - name: Configure libdispatch
         run: |

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -355,6 +355,105 @@ jobs:
           path: |
             ${{ github.workspace }}/BinaryCache/RegsGen2/regsgen2.exe
 
+  ds2:
+    needs: [ds2_tools]
+    runs-on: ${{ inputs.default_build_runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            cc: clang
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
+            cxx: clang++
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            os: Android
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=arm64-v8a
+
+          - arch: armv7
+            cc: clang
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
+            cxx: clang++
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            os: Android
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a
+
+          - arch: i686
+            cc: clang
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
+            cxx: clang++
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            os: Android
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86
+
+          - arch: x86_64
+            cc: clang
+            cflags: ${{ inputs.ANDROID_CMAKE_C_FLAGS }}
+            cxx: clang++
+            cxxflags: ${{ inputs.ANDROID_CMAKE_CXX_FLAGS }}
+            os: Android
+            extra_flags: -DCMAKE_ANDROID_API=${{ inputs.ANDROID_API_LEVEL }} -DCMAKE_ANDROID_ARCH_ABI=x86_64
+
+    name: ${{ matrix.os }} ${{ matrix.arch }} ds2
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: compnerd/ds2
+          ref: ${{ inputs.ds2_revision }}
+          path: ${{ github.workspace }}/SourceCache/ds2
+          show-progress: false
+
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
+
+      - name: Install Flex and Bison Tools
+        run: choco install winflexbison3
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-regsgen2
+          path: ${{ github.workspace }}/BinaryCache/RegsGen2
+
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r26b
+
+      - name: Configure DS2
+        run: |
+          $NDKPATH = cygpath -m ${{ steps.setup-ndk.outputs.ndk-path }}
+          cmake -B ${{ github.workspace }}/BinaryCache/ds2 `
+                -S ${{ github.workspace }}/SourceCache/ds2 `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${{ matrix.cc }} `
+                -D CMAKE_C_FLAGS="${{ matrix.cflags }}" `
+                -D CMAKE_CXX_COMPILER=${{ matrix.cxx }} `
+                -D CMAKE_CXX_FLAGS="${{ matrix.cxxflags }}" `
+                -D CMAKE_MT=mt `
+                -D MSVC_C_ARCHITECTURE_ID=${{ matrix.arch }} `
+                -D DS2_REGSGEN2=${{ github.workspace }}/BinaryCache/RegsGen2/regsgen2.exe `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BinaryCache/Library/Developer `
+                -D CMAKE_SYSTEM_NAME=${{ matrix.os }} `
+                -D CMAKE_ANDROID_NDK=$NDKPATH `
+                ${{ matrix.extra_flags }} `
+                -G Ninja
+
+      - name: Build DS2
+        run: cmake --build ${{ github.workspace }}/BinaryCache/ds2
+
+      - name: Install DS2
+        run: cmake --build ${{ github.workspace }}/BinaryCache/ds2 --target install
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ds2-${{ matrix.os }}-${{ matrix.arch }}
+          path: ${{ github.workspace }}/BinaryCache/Library/Developer
+
   cmark_gfm:
     runs-on: ${{ inputs.default_build_runner }}
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3515,12 +3515,16 @@ jobs:
         include:
           - arch: arm64
             cpu: aarch64
+            triple_no_api_level: aarch64-unknown-linux-android
           - arch: armv7
             cpu: armv7
+            triple_no_api_level: armv7-unknown-linux-androideabi
           - arch: i686
             cpu: i686
+            triple_no_api_level: i686-unknown-linux-android
           - arch: x86_64
             cpu: x86_64
+            triple_no_api_level: x86_64-unknown-linux-android
 
     steps:
       - uses: actions/download-artifact@v4
@@ -3535,7 +3539,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: ds2-Android-${{ matrix.arch }}
-          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/Library/Android/${{ matrix.cpu }}-unknown-linux-android
+          path: ${{ github.workspace }}/BuildRoot/Library/Developer/Platforms/Android.platform/Developer/Library/Android/${{ matrix.triple_no_api_level }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -311,6 +311,50 @@ jobs:
           name: sqlite-${{ matrix.os }}-${{ matrix.arch }}-${{ inputs.swift_toolchain_sqlite_version }}
           path: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
 
+  ds2_tools:
+    runs-on: ${{ inputs.default_build_runner }}
+
+    name: ds2 Build Tools
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: compnerd/ds2
+          ref: ${{ inputs.ds2_revision }}
+          path: ${{ github.workspace }}/SourceCache/ds2
+          show-progress: false
+
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: amd64
+
+      - name: Install Flex and Bison Tools
+        run: choco install winflexbison3
+
+      - name: Configure RegsGen2
+        run: |
+          cmake -B ${{ github.workspace }}/BinaryCache/RegsGen2 `
+                -S ${{ github.workspace }}/SourceCache/ds2/Tools/RegsGen2 `
+                -C ${{ github.workspace }}/SourceCache/ds2/cmake/caches/MSVCWarnings.cmake `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=cl `
+                -D CMAKE_CXX_COMPILER=cl `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_MT=mt `
+                -G Ninja
+
+      - name: Build RegsGen2
+        run: cmake --build ${{ github.workspace }}/BinaryCache/RegsGen2 --config Release
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-regsgen2
+          path: |
+            ${{ github.workspace }}/BinaryCache/RegsGen2/regsgen2.exe
+
   cmark_gfm:
     runs-on: ${{ inputs.default_build_runner }}
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -316,6 +316,8 @@ jobs:
           path: ${{ github.workspace }}/BuildRoot/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr
 
   ds2_tools:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.build_os == 'Windows'
     runs-on: ${{ inputs.default_build_runner }}
 
     name: ds2 Build Tools
@@ -363,6 +365,8 @@ jobs:
             ${{ github.workspace }}/BinaryCache/RegsGen2/regsgen2.exe
 
   ds2:
+    # TODO: Build this on macOS or make an equivalent Mac-only job
+    if: inputs.build_os == 'Windows'
     needs: [ds2_tools]
     runs-on: ${{ inputs.default_build_runner }}
 


### PR DESCRIPTION
Builds all 4 Android variants of compnerd/ds2 to be included in the Android SDK.

NOTE: ds2 is not yet referenced by `swift/swift-installer-scripts`, so this change does not have any effect other than validating the build.

### Test Plan
Manually inspected artifacts produced by the Android ds2 steps:
```
C:\Users\Andrew\Downloads>unzip -l ds2-Android-arm64.zip
Archive:  ds2-Android-arm64.zip
  Length     EAs   ACLs    Date   Time    Name
 --------    ---   ----    ----   ----    ----
 11907472      0      0  08/24/24 17:31   bin/ds2
 --------  -----  -----                   -------
 11907472      0      0                   1 file

C:\Users\Andrew\Downloads>unzip -l ds2-Android-armv7.zip
Archive:  ds2-Android-armv7.zip
  Length     EAs   ACLs    Date   Time    Name
 --------    ---   ----    ----   ----    ----
 10356780      0      0  08/26/24 15:19   bin/ds2
 --------  -----  -----                   -------
 10356780      0      0                   1 file

C:\Users\Andrew\Downloads>unzip -l ds2-Android-i686.zip
Archive:  ds2-Android-i686.zip
  Length     EAs   ACLs    Date   Time    Name
 --------    ---   ----    ----   ----    ----
 10048944      0      0  08/26/24 15:19   bin/ds2
 --------  -----  -----                   -------
 10048944      0      0                   1 file

C:\Users\Andrew\Downloads>unzip -l ds2-Android-x86_64.zip
Archive:  ds2-Android-x86_64.zip
  Length     EAs   ACLs    Date   Time    Name
 --------    ---   ----    ----   ----    ----
 11268640      0      0  08/26/24 15:21   bin/ds2
 --------  -----  -----                   -------
 11268640      0      0                   1 file
```