### PR TITLE
Update bigquery_generate_table_data.py

### DIFF
--- a/scripts/python/binary_sizes/bigquery_generate_table_data.py
+++ b/scripts/python/binary_sizes/bigquery_generate_table_data.py
@@ -24,7 +24,7 @@ import argparse
 import os
 import pandas as pd
 from datetime import datetime
-from bigquery_schema import BQ_SCHEMA
+from bigquery_schema import BQ_SCHEMA                                                                                                                                    
 
 def strip_prefix_from_column_values(csv_data, column_name, prefix):
     csv_data[column_name] = csv_data[column_name].apply(lambda x: x[len(prefix):])


### PR DESCRIPTION
[Line No 29-30]Strip the specified prefix from the values in the given column. 

def strip_prefix_from_column_values(csv_data, column_name, prefix):
 
    csv_data[column_name] = csv_data[column_name].str.lstrip(prefix)