### PR TITLE
Roll Windows image from 2024-05-17 to 2024-10-10

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,10 +1,25 @@
+# Self-Hosted Github Action Runners on Azure via https://cirun.io
+#
+# cirun reference:
+# - https://docs.cirun.io/reference/yaml
+# - https://docs.cirun.io/cloud/azure
+# - https://docs.cirun.io/custom-images/cloud-custom-images#azure-custom-images
+#
+# Updating the base image version:
+# - ./scripts/python/roll_cirun.py --version <new_version>
+#
+# VM shapes:
+# - ARM64 (Ampere): https://learn.microsoft.com/en-us/azure/virtual-machines/dplsv5-dpldsv5-series
+#   ARM64 (Cobalt): https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dpldsv6-series
+# - X64: https://learn.microsoft.com/en-us/azure/virtual-machines/fsv2-series
+# - X64: https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dadsv5-series
 runners:
   - name: win11-23h2-pro-arm64-16
     cloud: azure
     instance_type: Standard_D16plds_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.17"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.10.10"
     labels:
-      - cirun-win11-23h2-pro-arm64-16-2024-05-17
+      - cirun-win11-23h2-pro-arm64-16-2024-10-10
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -12,9 +27,9 @@ runners:
   - name: win11-23h2-pro-arm64-64
     cloud: azure
     instance_type: Standard_D64plds_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.05.17"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.10.10"
     labels:
-      - cirun-win11-23h2-pro-arm64-64-2024-05-17
+      - cirun-win11-23h2-pro-arm64-64-2024-10-10
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -22,9 +37,9 @@ runners:
   - name: win11-23h2-pro-x64-16
     cloud: azure
     instance_type: Standard_F16s_v2
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.05.17"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.10.10"
     labels:
-      - cirun-win11-23h2-pro-x64-16-2024-05-17
+      - cirun-win11-23h2-pro-x64-16-2024-10-10
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -32,9 +47,9 @@ runners:
   - name: win11-23h2-pro-x64-64
     cloud: azure
     instance_type: Standard_D64ads_v5
-    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.05.17"
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.10.10"
     labels:
-      - cirun-win11-23h2-pro-x64-64-2024-05-17
+      - cirun-win11-23h2-pro-x64-64-2024-10-10
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner

--- a/.github/workflows/pull-request-swift-toolchain-cirun.yml
+++ b/.github/workflows/pull-request-swift-toolchain-cirun.yml
@@ -17,8 +17,8 @@ jobs:
     uses: ./.github/workflows/build-toolchain.yml
     with:
       create_release: false
-      windows_default_runner: "cirun-win11-23h2-pro-x64-16-2024-05-17--${{ github.run_id }}"
-      windows_compilers_runner: "cirun-win11-23h2-pro-x64-64-2024-05-17--${{ github.run_id }}"
+      windows_default_runner: "cirun-win11-23h2-pro-x64-16-2024-10-10--${{ github.run_id }}"
+      windows_compilers_runner: "cirun-win11-23h2-pro-x64-64-2024-10-10--${{ github.run_id }}"
       android_api_level: 28
     secrets: inherit
     permissions:

--- a/.github/workflows/release-6-0-swift-toolchain-schedule.yml
+++ b/.github/workflows/release-6-0-swift-toolchain-schedule.yml
@@ -14,8 +14,8 @@ jobs:
     uses: thebrowsercompany/swift-build/.github/workflows/build-toolchain.yml@release/6.0
     with:
       create_release: true
-      windows_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-2024-05-17--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
-      windows_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-2024-05-17--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
+      windows_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-2024-10-10--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
+      windows_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-2024-10-10--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
       android_api_level: 28
     secrets:
       SYMBOL_SERVER_PAT: ${{ secrets.SYMBOL_SERVER_PAT }}

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -64,7 +64,7 @@ jobs:
             },
             {
               "arch": "arm64",
-              "os": "cirun-win11-23h2-pro-arm64-16-2024-05-17--${{ github.run_id }}",
+              "os": "cirun-win11-23h2-pro-arm64-16-2024-10-10--${{ github.run_id }}",
               "is_cirun": "true"
             }
           ]

--- a/.github/workflows/schedule-swift-toolchain.yml
+++ b/.github/workflows/schedule-swift-toolchain.yml
@@ -14,8 +14,8 @@ jobs:
     uses: ./.github/workflows/build-toolchain.yml
     with:
       create_release: true
-      windows_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-2024-05-17--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
-      windows_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-2024-05-17--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
+      windows_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-2024-10-10--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
+      windows_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-2024-10-10--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
       android_api_level: 28
     secrets: inherit
     permissions:


### PR DESCRIPTION
Add comment in .cirun.yml with references and a tip on how to roll it next time.