### PR TITLE
Skip release-swift-toolchain-binary-sizes.yml on PR validation

### DIFF
--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -10,10 +10,6 @@
 name: Release - Swift Toolchain Binary Sizes
 
 on:
-  pull_request:
-    paths:
-      - .github/workflows/release-swift-toolchain-binary-sizes.yml
-
   release:
     types: [created, edited]
 


### PR DESCRIPTION
This is currently broken due to a missing python package, and is preventing us from rolling windows VM images