### PR TITLE
Add id-token write permission for BCNY flows

### DIFF
--- a/.github/workflows/pull-request-swift-toolchain-cirun.yml
+++ b/.github/workflows/pull-request-swift-toolchain-cirun.yml
@@ -26,4 +26,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      id-token: write
 

--- a/.github/workflows/pull-request-swift-toolchain-github.yml
+++ b/.github/workflows/pull-request-swift-toolchain-github.yml
@@ -25,4 +25,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      id-token: write
 


### PR DESCRIPTION
Since these workflows are top-level entry points, they need to have the `id-token: write` permission to allow for OIDC to work from GitHub.