### PR TITLE
[CI] Add 2024-12-19 back to unbreak Release 6.2

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -20,6 +20,7 @@ runners:
     machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2025.03.13"
     labels:
       - cirun-win11-23h2-pro-arm64-16-2025-03-13
+      - cirun-win11-23h2-pro-arm64-16
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -30,6 +31,7 @@ runners:
     machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2025.03.13"
     labels:
       - cirun-win11-23h2-pro-arm64-64-2025-03-13
+      - cirun-win11-23h2-pro-arm64-64
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -40,6 +42,7 @@ runners:
     machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2025.03.13"
     labels:
       - cirun-win11-23h2-pro-x64-16-2025-03-13
+      - cirun-win11-23h2-pro-x64-16
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner
@@ -50,6 +53,48 @@ runners:
     machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2025.03.13"
     labels:
       - cirun-win11-23h2-pro-x64-64-2025-03-13
+      - cirun-win11-23h2-pro-x64-64
+    extra_config:
+      runner_path: "D:\\r"
+      runner_user: runner
+      run_as: interactive
+  # TODO: Remove the following once another release is made.
+  - name: win11-23h2-pro-arm64-16
+    cloud: azure
+    instance_type: Standard_D16plds_v5
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.12.19"
+    labels:
+      - cirun-win11-23h2-pro-arm64-16-2024-12-19
+    extra_config:
+      runner_path: "D:\\r"
+      runner_user: runner
+      run_as: interactive
+  - name: win11-23h2-pro-arm64-64
+    cloud: azure
+    instance_type: Standard_D64plds_v5
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-arm64/versions/2024.12.19"
+    labels:
+      - cirun-win11-23h2-pro-arm64-64-2024-12-19
+    extra_config:
+      runner_path: "D:\\r"
+      runner_user: runner
+      run_as: interactive
+  - name: win11-23h2-pro-x64-16
+    cloud: azure
+    instance_type: Standard_F16s_v2
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.12.19"
+    labels:
+      - cirun-win11-23h2-pro-x64-16-2024-12-19
+    extra_config:
+      runner_path: "D:\\r"
+      runner_user: runner
+      run_as: interactive
+  - name: win11-23h2-pro-x64-64
+    cloud: azure
+    instance_type: Standard_D64ads_v5
+    machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-23h2-pro-x64/versions/2024.12.19"
+    labels:
+      - cirun-win11-23h2-pro-x64-64-2024-12-19
     extra_config:
       runner_path: "D:\\r"
       runner_user: runner


### PR DESCRIPTION
- Release 6.2 uses an older code base that doess't have the fix to be compatible with the new Azure Windows image.
- Further, due to the github merge base bug, cirun see the new github workflows from main but the old .cirun.yml file, causing a mismatch in the labels requested versus defined.
- Add unversioned labels so we can switch to these later once a new release it done.