### PR TITLE
Update configure-aws-credentials and ccache-action

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -63,13 +63,13 @@ runs:
 
     - name: Setup sccache (remote)
       if: inputs.aws-arn != '' && steps.aws-credentials.outcome == 'success'
-      uses: thebrowsercompany/ccache-action@2bb339feaeb58ab618f79d7ab9e5dda7a73f3beb
+      uses: thebrowsercompany/ccache-action@2bb339feaeb58ab618f79d7ab9e5dda7a73f3beb # main
       with:
         variant: sccache
 
     - name: Setup sccache (local)
       if: inputs.aws-arn == ''
-      uses: thebrowsercompany/ccache-action@2bb339feaeb58ab618f79d7ab9e5dda7a73f3beb
+      uses: thebrowsercompany/ccache-action@2bb339feaeb58ab618f79d7ab9e5dda7a73f3beb # main
       with:
         max-size: ${{ inputs.disk-max-size }}
         key: ${{ inputs.disk-cache-key }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -53,7 +53,7 @@ runs:
 
     - name: Authenticate to AWS
       id: aws-credentials
-      uses: aws-actions/configure-aws-credentials@v4.1.0
+      uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
       if: inputs.aws-arn != ''
       with:
         role-to-assume: ${{ inputs.aws-arn }}

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -53,12 +53,13 @@ runs:
 
     - name: Authenticate to AWS
       id: aws-credentials
-      uses: aws-actions/configure-aws-credentials@v3
+      uses: aws-actions/configure-aws-credentials@v4.1.0
       if: inputs.aws-arn != ''
       with:
         role-to-assume: ${{ inputs.aws-arn }}
         role-session-name: ToolchainCISccacheAccess
         aws-region: ${{ inputs.aws-region }}
+        special-characters-workaround: 'true' # special characters in secrets can cause SignatureDoesNotMatch errors
 
     - name: Setup sccache (remote)
       if: inputs.aws-arn != '' && steps.aws-credentials.outcome == 'success'

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -63,13 +63,13 @@ runs:
 
     - name: Setup sccache (remote)
       if: inputs.aws-arn != '' && steps.aws-credentials.outcome == 'success'
-      uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
+      uses: thebrowsercompany/ccache-action@2bb339feaeb58ab618f79d7ab9e5dda7a73f3beb
       with:
         variant: sccache
 
     - name: Setup sccache (local)
       if: inputs.aws-arn == ''
-      uses: hendrikmuhs/ccache-action@a1209f81afb8c005c13b4296c32e363431bffea5 # v1.2.17
+      uses: thebrowsercompany/ccache-action@2bb339feaeb58ab618f79d7ab9e5dda7a73f3beb
       with:
         max-size: ${{ inputs.disk-max-size }}
         key: ${{ inputs.disk-cache-key }}


### PR DESCRIPTION
These changes attempt to address the intermittent failure we are seeing during the sccache initialization (DEVEX-2830).

Current prognosis is that the `403` failures are coming from mismatched request signature validation between client and server. The error and symptoms look a lot like this issue: aws/aws-cli#2665.

To attempt to remedy this, I have two changes:

1. Switch to use `thebrowsercompany/ccache-action` instead of `hendrikmuhs/ccache-action`.  
   The only difference is updating to a newer version of sccache (`v0.10.0` instead of `v0.7.6`).  
   The changes between the two are pushed to a PR (Update sccache version to v0.10.0: hendrikmuhs/ccache-action#315). Once merged, we can revert back to the upstream release.  
   This change does not resolve the issue, but it was helpful during debugging, as the new sccache has more verbose error reporting by default.

2. Update `configure-aws-credentials` to the latest version.  
   This update uses the `special-characters-workaround` flag that was introduced last year.  
   The flag seems to address the issue we are running into. The action will now check if the AWS secrets have any special characters ("+" or "/" among others), and if so, it will request a new identity.  
   See details in the original issue:  [#599](https://github.com/aws-actions/configure-aws-credentials/issues/599), and linked aws-cli issue [#2665](https://github.com/aws/aws-cli/issues/2665)


As for testing, I have focused on volume. before these changes, rate seems to be about 20% of the jobs running into this issue on first run. here are latest jobs on this branch: https://github.com/thebrowsercompany/swift-build/actions/workflows/build-toolchain.yml?query=branch%3Amhegazy%2Fupdate-configure-aws-credentials


Resolves DEVEX-2830.

compnerd/swift-build matching PR: https://github.com/compnerd/swift-build/pull/946