### PR TITLE
GHA: add swift-build to the build

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2880,6 +2880,12 @@ jobs:
           show-progress: false
       - uses: actions/checkout@v4.2.2
         with:
+          repository: swiftlang/swift-build
+          ref: ${{ inputs.swift_build_revision }}
+          path: ${{ github.workspace }}/SourceCache/swift-build
+          show-progress: false
+      - uses: actions/checkout@v4.2.2
+        with:
           repository: swiftlang/swift-package-manager
           ref: ${{ inputs.swift_package_manager_revision }}
           path: ${{ github.workspace }}/SourceCache/swift-package-manager
@@ -3239,6 +3245,43 @@ jobs:
       - name: Build swift-certificates
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-certificates
 
+      - name: Configure swift-build
+        run: |
+          # Workaround CMake 3.20 issue
+          $CLANG_CL = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/clang-cl.exe
+          $SWIFTC = cygpath -m ${{ github.workspace }}/BinaryCache/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr/bin/swiftc.exe
+
+          cmake -B ${{ github.workspace }}/BinaryCache/swift-build `
+                -D BUILD_SHARED_LIBS=YES `
+                -D BUILD_TESTING=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=${CLANG_CL} `
+                -D CMAKE_C_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_C_FLAGS="${{ inputs.WINDOWS_CMAKE_C_FLAGS }}" `
+                -D CMAKE_CXX_COMPILER=${CLANG_CL} `
+                -D CMAKE_CXX_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_CXX_FLAGS="${{ inputs.WINDOWS_CMAKE_CXX_FLAGS }}" `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/Developer/Toolchains/${{ inputs.swift_version }}+Asserts/usr `
+                -D CMAKE_Swift_COMPILER=${SWIFTC} `
+                -D CMAKE_Swift_COMPILER_TARGET=${{ matrix.triple }} `
+                -D CMAKE_Swift_COMPILER_WORKS=YES `
+                -D CMAKE_Swift_FLAGS="-sdk ${env:SDKROOT} ${{ inputs.CMAKE_Swift_FLAGS }}" `
+                -D CMAKE_Swift_FLAGS_RELEASE="-O" `
+                ${{ matrix.cmake_linker_flags }} `
+                -D CMAKE_SYSTEM_NAME=Windows `
+                -D CMAKE_SYSTEM_PROCESSOR=${{ matrix.cpu }} `
+                -G Ninja `
+                -S ${{ github.workspace }}/SourceCache/swift-build `
+                -D ArgumentParser_DIR=${{ github.workspace }}/BinaryCache/swift-argument-parser/cmake/modules `
+                -D LLBuild_DIR=${{ github.workspace }}/BinaryCache/swift-llbuild/cmake/modules `
+                -D SwiftDriver_DIR=${{ github.workspace }}/BinaryCache/swift-driver/cmake/modules `
+                -D SwiftSystem_DIR=${{ github.workspace }}/BinaryCache/swift-system/cmake/modules `
+                -D TSC_DIR=${{ github.workspace }}/BinaryCache/swift-tools-support-core/cmake/modules `
+                -D SQLite3_INCLUDE_DIR=${{ github.workspace }}/BinaryCache/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/include `
+                -D SQLite3_LIBRARY=${{ github.workspace }}/BinaryCache/Library/sqlite-${{ inputs.swift_toolchain_sqlite_version }}/usr/lib/SQLite3.lib
+      - name: Build swift-build
+        run: swift --build ${{ github.workspace }}/BinaryCache/swift-build
+
       - name: extract swift-syntax
         run: |
           $module = "${{ github.workspace }}/BinaryCache/swift-syntax/cmake/modules/SwiftSyntaxConfig.cmake"
@@ -3452,6 +3495,8 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-tools-support-core --target install
       - name: Install swift-driver
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-driver --target install
+      - name: Install swift-build
+        run: cmake --build ${{ github.workspace }}/BinaryCache/swift-build --target install
       - name: Install swift-package-manager
         run: cmake --build ${{ github.workspace }}/BinaryCache/swift-package-manager --target install
       - name: Install SourceKit-LSP


### PR DESCRIPTION
Prepare to build swift-build in the toolchain build as it is about to the packaged up into the installer.