### PR TITLE
Update ccache-action to v1.2.18

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -63,13 +63,13 @@ runs:
 
     - name: Setup sccache (remote)
       if: inputs.aws-arn != '' && steps.aws-credentials.outcome == 'success'
-      uses: thebrowsercompany/ccache-action@2bb339feaeb58ab618f79d7ab9e5dda7a73f3beb # main
+      uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2.18
       with:
         variant: sccache
 
     - name: Setup sccache (local)
       if: inputs.aws-arn == ''
-      uses: thebrowsercompany/ccache-action@2bb339feaeb58ab618f79d7ab9e5dda7a73f3beb # main
+      uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2.18
       with:
         max-size: ${{ inputs.disk-max-size }}
         key: ${{ inputs.disk-cache-key }}


### PR DESCRIPTION
Now that we have an official release of ccache-action switch to it: https://github.com/hendrikmuhs/ccache-action/releases/tag/v1.2.18

`compnerd/swift-build` matching PR: https://github.com/compnerd/swift-build/pull/950