### PR TITLE
Set `dry_run` to false when running Binary size workflow in releases

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1021,5 +1021,6 @@ jobs:
     uses: ./.github/workflows/release-swift-toolchain-binary-sizes.yml
     with:
       toolchain_version: ${{ needs.context.outputs.swift_tag }}
+      dry_run: false
     secrets:
       SWIFT_TOOLCHAIN_UPLOADER_ROLE_ARN: ${{ secrets.SWIFT_TOOLCHAIN_UPLOADER_ROLE_ARN }}


### PR DESCRIPTION
We were running the wokflow, but not uploading the data, see https://github.com/thebrowsercompany/swift-build/actions/runs/15317512353/job/43103266498