### PR TITLE
GHA: enable public IP for Azure VMs

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -22,6 +22,7 @@ runners:
       - cirun-win11-23h2-pro-arm64-16-2025-03-13
       - cirun-win11-23h2-pro-arm64-16
     extra_config:
+      enable_public_ip: true
       runner_path: "D:\\r"
       runner_user: runner
       run_as: interactive
@@ -33,6 +34,7 @@ runners:
       - cirun-win11-23h2-pro-arm64-64-2025-03-13
       - cirun-win11-23h2-pro-arm64-64
     extra_config:
+      enable_public_ip: true
       runner_path: "D:\\r"
       runner_user: runner
       run_as: interactive
@@ -44,6 +46,7 @@ runners:
       - cirun-win11-23h2-pro-x64-16-2025-03-13
       - cirun-win11-23h2-pro-x64-16
     extra_config:
+      enable_public_ip: true
       runner_path: "D:\\r"
       runner_user: runner
       run_as: interactive
@@ -55,6 +58,7 @@ runners:
       - cirun-win11-23h2-pro-x64-64-2025-03-13
       - cirun-win11-23h2-pro-x64-64
     extra_config:
+      enable_public_ip: true
       runner_path: "D:\\r"
       runner_user: runner
       run_as: interactive
@@ -66,6 +70,7 @@ runners:
     labels:
       - cirun-win11-23h2-pro-arm64-16-2024-12-19
     extra_config:
+      enable_public_ip: true
       runner_path: "D:\\r"
       runner_user: runner
       run_as: interactive
@@ -76,6 +81,7 @@ runners:
     labels:
       - cirun-win11-23h2-pro-arm64-64-2024-12-19
     extra_config:
+      enable_public_ip: true
       runner_path: "D:\\r"
       runner_user: runner
       run_as: interactive
@@ -86,6 +92,7 @@ runners:
     labels:
       - cirun-win11-23h2-pro-x64-16-2024-12-19
     extra_config:
+      enable_public_ip: true
       runner_path: "D:\\r"
       runner_user: runner
       run_as: interactive
@@ -96,6 +103,7 @@ runners:
     labels:
       - cirun-win11-23h2-pro-x64-64-2024-12-19
     extra_config:
+      enable_public_ip: true
       runner_path: "D:\\r"
       runner_user: runner
       run_as: interactive


### PR DESCRIPTION
Default outbound access for VMs without an IP address will be disabled in September 2025.

https://azure.microsoft.com/en-us/updates?id=default-outbound-access-for-vms-in-azure-will-be-retired-updates-and-more-information
