### PR TITLE
Add retry logic to MSVC install step

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -177,19 +177,18 @@ runs:
         name: ${{ github.job }}-windows-sdk-installer-log
         path: ${{ steps.setup-windows-sdk.outputs.log-file }}
 
-    - name: Install Windows MSVC version 14.42
-      if: steps.sanitize-input.outputs.build-os == 'windows'
+    - name: Install Windows MSVC version ${{ inputs.msvc-version }}
+      if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.msvc-version != ''
       id: setup-msvc
       shell: pwsh
       run: |
         $script:LogFiles = @()
         function Install-MSVC {
-          Write-Host "ℹ️ In Install-MSVC..."
           try {
             # This is assuming a VS2022 toolchain. e.g.
             # MSVC 14.42 corresponds to the 14.42.17.12 package.
             # MSVC 14.43 corresponds to the 14.43.17.13 package.
-            $MSVCVersionString = "14.42"
+            $MSVCVersionString = "${{ inputs.msvc-version }}"
 
             $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
             $VSWhere = Join-Path "${InstallerLocation}" "VSWhere.exe"
@@ -234,17 +233,11 @@ runs:
               }
             }
 
-            if ($MSVCBuildToolsVersion -ne "") {
-              Write-Host "ℹ️ Installation passed. Injecting failure!"
-              $MSVCBuildToolsVersion = ""
-            }
-
             if ($MSVCBuildToolsVersion -eq "") {
               Write-Host "::error::Failed to install MSVC ${MSVCVersionString}. Check the installer log for details."
               $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
               write-Host "ℹ️ Found Installer log: $($LogFile.FullName)"
               $script:LogFiles += $LogFile.FullName
-              Write-Host "The size of the array is $($script:LogFiles.Length)"
               return $false
             } else {
               Write-Host "ℹ️ MSVC ${MSVCBuildToolsVersion} installed successfully."
@@ -262,7 +255,6 @@ runs:
         for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
             Write-Host "ℹ️ Attempt $attempt of $maxAttempts to install MSVC..."
             $success = Install-MSVC
-            Write-Host "Install-MSVC returned: $success"
             if ($success) {
                 Write-Host "ℹ️ MSVC install successed on attempt: $attempt."
                 break
@@ -272,7 +264,6 @@ runs:
             } else {
                 Write-Host "❌ All attempts to install MSVC failed."
                 if ($script:LogFiles.Count -gt 0) {
-                  Write-Host "ℹ️ Found Installer logs: $($script:LogFiles -join ', ')"
                   "log-files=$($script:LogFiles -join "`n" )" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
                 }
                 exit 1
@@ -285,12 +276,6 @@ runs:
       with:
         name: ${{ github.job }}-msvc-installer-log
         path: ${{ steps.setup-msvc.outputs.log-files }}
-
-    - name: Failure
-      shell: pwsh
-      run: |
-        Write-Output "::error::Failed to set up the build environment. Check the logs for details."
-        exit 1
 
     - name: Setup Visual Studio Developer Environment
       if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.setup-vs-dev-env == 'true'

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -182,70 +182,111 @@ runs:
       id: setup-msvc
       shell: pwsh
       run: |
-        # This is assuming a VS2022 toolchain. e.g.
-        # MSVC 14.42 corresponds to the 14.42.17.12 package.
-        # MSVC 14.43 corresponds to the 14.43.17.13 package.
-        $MSVCVersionString = "${{ inputs.msvc-version }}"
+        $LogFiles = @()
+        function Install-MSVC {
+          try {
+            # This is assuming a VS2022 toolchain. e.g.
+            # MSVC 14.42 corresponds to the 14.42.17.12 package.
+            # MSVC 14.43 corresponds to the 14.43.17.13 package.
+            $MSVCVersionString = "${{ inputs.msvc-version }}"
 
-        $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
-        $VSWhere = Join-Path "${InstallerLocation}" "VSWhere.exe"
-        $VSInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
-        $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
-        $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
+            $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
+            $VSWhere = Join-Path "${InstallerLocation}" "VSWhere.exe"
+            $VSInstaller = Join-Path "${InstallerLocation}" "vs_installer.exe"
+            $InstallPath = (& "$VSWhere" -latest -products * -format json | ConvertFrom-Json).installationPath
+            $MSVCDir = Join-Path $InstallPath "VC" "Tools" "MSVC"
 
-        # Compute the MSVC version package name from the MSVC version, assuming this is coming from
-        # a VS2022 installation. The version package follows the following format:
-        # * Major and minor version are the same as the MSVC version.
-        # * Build version is always 17 (VS2002 is VS17).
-        # * The revision is set to the number of minor versions since VS17 release.
-        $MSVCVersion = [System.Version]::Parse($MSVCVersionString)
-        $MajorVersion = $MSVCVersion.Major
-        $MinorVersion = $MSVCVersion.Minor
-        $BuildVersion = 17
-        $RevisionVersion = $MinorVersion - 30
-        $MSVCPackageVersion = "${MajorVersion}.${MinorVersion}.${BuildVersion}.${RevisionVersion}"
+            # Compute the MSVC version package name from the MSVC version, assuming this is coming from
+            # a VS2022 installation. The version package follows the following format:
+            # * Major and minor version are the same as the MSVC version.
+            # * Build version is always 17 (VS2002 is VS17).
+            # * The revision is set to the number of minor versions since VS17 release.
+            $MSVCVersion = [System.Version]::Parse($MSVCVersionString)
+            $MajorVersion = $MSVCVersion.Major
+            $MinorVersion = $MSVCVersion.Minor
+            $BuildVersion = 17
+            $RevisionVersion = $MinorVersion - 30
+            $MSVCPackageVersion = "${MajorVersion}.${MinorVersion}.${BuildVersion}.${RevisionVersion}"
 
-        # Install the missing MSVC version.
-        Write-Output "ℹ️ Installing MSVC packages for ${MSVCPackageVersion}..."
-        $process = Start-Process "$VSInstaller" `
-            -PassThru `
-            -ArgumentList "modify", `
-                "--installPath", "`"$InstallPath`"", `
-                "--channelId", "https://aka.ms/vs/17/release/channel", `
-                "--quiet", "--norestart", "--nocache", `
-                "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.x86.x64", `
-                "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ATL", `
-                "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ARM64", `
-                "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ATL.ARM64"
-        $process.WaitForExit()
+            # Install the missing MSVC version.
+            Write-Output "ℹ️ Installing MSVC packages for ${MSVCPackageVersion}..."
+            $process = Start-Process "$VSInstaller" `
+                -PassThru `
+                -ArgumentList "modify", `
+                    "--installPath", "`"$InstallPath`"", `
+                    "--channelId", "https://aka.ms/vs/17/release/channel", `
+                    "--quiet", "--norestart", "--nocache", `
+                    "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.x86.x64", `
+                    "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ATL", `
+                    "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ARM64", `
+                    "--add", "Microsoft.VisualStudio.Component.VC.${MSVCPackageVersion}.ATL.ARM64"
+            $process.WaitForExit()
 
-        # Check if the MSVC version was installed successfully.
-        $MSVCBuildToolsVersion = ""
-        foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
-          $MSVCDirName = $dir.Name
-          if ($MSVCDirName.StartsWith($MSVCVersionString)) {
-            Write-Output "ℹ️ MSVC ${MSVCVersionString} installed successfully."
-            $MSVCBuildToolsVersion = $MsvcDirName
-            break
+            # Check if the MSVC version was installed successfully.
+            $MSVCBuildToolsVersion = ""
+            foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
+              $MSVCDirName = $dir.Name
+              if ($MSVCDirName.StartsWith($MSVCVersionString)) {
+                Write-Output "ℹ️ MSVC ${MSVCVersionString} installed successfully."
+                $MSVCBuildToolsVersion = $MsvcDirName
+                break
+              }
+            }
+
+            if ($MSVCBuildToolsVersion -ne "") {
+              Write-Output "ℹ️ Installation passed. Injecting failure!"
+              $MSVCBuildToolsVersion = ""
+            }
+
+            if ($MSVCBuildToolsVersion -eq "") {
+              Write-Output "::error::Failed to install MSVC ${MSVCVersionString}. Check the installer log for details."
+              $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+              $LogFiles += $LogFile.FullName
+              return $false
+            } else {
+              Write-Output "ℹ️ MSVC ${MSVCBuildToolsVersion} installed successfully."
+              "windows-build-tools-version=${MSVCBuildToolsVersion}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+              return $true
+            }
+          } catch {
+              Write-Output "❌ Exception caught in Install-MSVC: $_"
+              return $false
           }
         }
 
-        if ($MSVCBuildToolsVersion -eq "") {
-          Write-Output "::error::Failed to install MSVC ${MSVCVersionString}. Check the installer log for details."
-          $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-          "log-file=$($LogFile.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          exit 1
-        } else {
-          Write-Output "ℹ️ MSVC ${MSVCBuildToolsVersion} installed successfully."
-          "windows-build-tools-version=${MSVCBuildToolsVersion}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        # Retry logic: up to 3 attempts, sleep 1 minute between failures
+        $maxAttempts = 3
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Output "ℹ️ Attempt $attempt of $maxAttempts to install MSVC..."
+            $success = Install-MSVC
+            if ($success) {
+                Write-Output "ℹ️ MSVC install successed on attempt: $attempt."
+                break
+            } elseif ($attempt -lt $maxAttempts) {
+                Write-Output "ℹ️ MSVC Install failed on attempt: $attempt. Waiting 1 minute before retrying..."
+                Start-Sleep -Seconds 60
+            } else {
+                Write-Output "❌ All attempts to install MSVC failed."
+                if ($LogFiles.Count -gt 0) {
+                  Write-Output "ℹ️ Found Installer logs: $($LogFiles -join ', ')"
+                  "log-files=$($LogFiles -join '`n')" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+                }
+                exit 1
+            }
         }
 
-    - name: Upload installer log
-      if: always() && steps.setup-msvc.outputs.log-file != ''
+    - name: Upload installer logs
+      if: always() && steps.setup-msvc.outputs.log-files != ''
       uses: actions/upload-artifact@v4
       with:
         name: ${{ github.job }}-msvc-installer-log
-        path: ${{ steps.setup-msvc.outputs.log-file }}
+        path: ${{ steps.setup-msvc.outputs.log-files }}
+
+    - name: Failure
+      shell: pwsh
+      run: |
+        Write-Output "::error::Failed to set up the build environment. Check the logs for details."
+        exit 1
 
     - name: Setup Visual Studio Developer Environment
       if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.setup-vs-dev-env == 'true'

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -177,18 +177,19 @@ runs:
         name: ${{ github.job }}-windows-sdk-installer-log
         path: ${{ steps.setup-windows-sdk.outputs.log-file }}
 
-    - name: Install Windows MSVC version ${{ inputs.msvc-version }}
-      if: steps.sanitize-input.outputs.build-os == 'windows' && inputs.msvc-version != ''
+    - name: Install Windows MSVC version 14.42
+      if: steps.sanitize-input.outputs.build-os == 'windows'
       id: setup-msvc
       shell: pwsh
       run: |
-        $LogFiles = @()
+        $script:LogFiles = @()
         function Install-MSVC {
+          Write-Host "ℹ️ In Install-MSVC..."
           try {
             # This is assuming a VS2022 toolchain. e.g.
             # MSVC 14.42 corresponds to the 14.42.17.12 package.
             # MSVC 14.43 corresponds to the 14.43.17.13 package.
-            $MSVCVersionString = "${{ inputs.msvc-version }}"
+            $MSVCVersionString = "14.42"
 
             $InstallerLocation = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio" "Installer"
             $VSWhere = Join-Path "${InstallerLocation}" "VSWhere.exe"
@@ -209,7 +210,7 @@ runs:
             $MSVCPackageVersion = "${MajorVersion}.${MinorVersion}.${BuildVersion}.${RevisionVersion}"
 
             # Install the missing MSVC version.
-            Write-Output "ℹ️ Installing MSVC packages for ${MSVCPackageVersion}..."
+            Write-Host "ℹ️ Installing MSVC packages for ${MSVCPackageVersion}..."
             $process = Start-Process "$VSInstaller" `
                 -PassThru `
                 -ArgumentList "modify", `
@@ -227,29 +228,31 @@ runs:
             foreach ($dir in Get-ChildItem -Path $MSVCDir -Directory) {
               $MSVCDirName = $dir.Name
               if ($MSVCDirName.StartsWith($MSVCVersionString)) {
-                Write-Output "ℹ️ MSVC ${MSVCVersionString} installed successfully."
+                Write-Host "ℹ️ MSVC ${MSVCVersionString} installed successfully."
                 $MSVCBuildToolsVersion = $MsvcDirName
                 break
               }
             }
 
             if ($MSVCBuildToolsVersion -ne "") {
-              Write-Output "ℹ️ Installation passed. Injecting failure!"
+              Write-Host "ℹ️ Installation passed. Injecting failure!"
               $MSVCBuildToolsVersion = ""
             }
 
             if ($MSVCBuildToolsVersion -eq "") {
-              Write-Output "::error::Failed to install MSVC ${MSVCVersionString}. Check the installer log for details."
+              Write-Host "::error::Failed to install MSVC ${MSVCVersionString}. Check the installer log for details."
               $LogFile = Get-ChildItem "${env:TEMP}" -Filter "dd_installer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-              $LogFiles += $LogFile.FullName
+              write-Host "ℹ️ Found Installer log: $($LogFile.FullName)"
+              $script:LogFiles += $LogFile.FullName
+              Write-Host "The size of the array is $($script:LogFiles.Length)"
               return $false
             } else {
-              Write-Output "ℹ️ MSVC ${MSVCBuildToolsVersion} installed successfully."
+              Write-Host "ℹ️ MSVC ${MSVCBuildToolsVersion} installed successfully."
               "windows-build-tools-version=${MSVCBuildToolsVersion}" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
               return $true
             }
           } catch {
-              Write-Output "❌ Exception caught in Install-MSVC: $_"
+              Write-Host "❌ Exception caught in Install-MSVC: $_"
               return $false
           }
         }
@@ -257,19 +260,20 @@ runs:
         # Retry logic: up to 3 attempts, sleep 1 minute between failures
         $maxAttempts = 3
         for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-            Write-Output "ℹ️ Attempt $attempt of $maxAttempts to install MSVC..."
+            Write-Host "ℹ️ Attempt $attempt of $maxAttempts to install MSVC..."
             $success = Install-MSVC
+            Write-Host "Install-MSVC returned: $success"
             if ($success) {
-                Write-Output "ℹ️ MSVC install successed on attempt: $attempt."
+                Write-Host "ℹ️ MSVC install successed on attempt: $attempt."
                 break
             } elseif ($attempt -lt $maxAttempts) {
-                Write-Output "ℹ️ MSVC Install failed on attempt: $attempt. Waiting 1 minute before retrying..."
+                Write-Host "ℹ️ MSVC Install failed on attempt: $attempt. Waiting 1 minute before retrying..."
                 Start-Sleep -Seconds 60
             } else {
-                Write-Output "❌ All attempts to install MSVC failed."
-                if ($LogFiles.Count -gt 0) {
-                  Write-Output "ℹ️ Found Installer logs: $($LogFiles -join ', ')"
-                  "log-files=$($LogFiles -join '`n')" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+                Write-Host "❌ All attempts to install MSVC failed."
+                if ($script:LogFiles.Count -gt 0) {
+                  Write-Host "ℹ️ Found Installer logs: $($script:LogFiles -join ', ')"
+                  "log-files=$($script:LogFiles -join "`n" )" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
                 }
                 exit 1
             }


### PR DESCRIPTION
Add retry logic to MSVC install step.

Changes:
- Wrap the existing logic in a function. and call it a max of 3 times, with a 1 min sleep in between
- Collect and upload all logs

Testing:
- run in progress: https://github.com/thebrowsercompany/swift-build/actions/runs/15696540005