### PR TITLE
Switch cirun labels on main branch to use a more generic label (no date)

### DIFF
--- a/.github/workflows/pull-request-swift-toolchain-cirun.yml
+++ b/.github/workflows/pull-request-swift-toolchain-cirun.yml
@@ -18,9 +18,9 @@ jobs:
     with:
       create_release: false
       windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
-      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
-      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
-      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
+      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
+      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16--{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
+      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64--{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
       android_api_level: 28
     secrets: inherit
     permissions:

--- a/.github/workflows/pull-request-swift-toolchain-cirun.yml
+++ b/.github/workflows/pull-request-swift-toolchain-cirun.yml
@@ -17,10 +17,10 @@ jobs:
     uses: ./.github/workflows/build-toolchain.yml
     with:
       create_release: false
-      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-2025-03-13--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
-      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-2025-03-13--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
-      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-2025-03-13--{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
-      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-2025-03-13--{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
+      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
+      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
+      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
+      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
       android_api_level: 28
     secrets: inherit
     permissions:

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -64,7 +64,7 @@ jobs:
             },
             {
               "arch": "arm64",
-              "os": "cirun-win11-23h2-pro-arm64-16-2025-03-13--${{ github.run_id }}",
+              "os": "cirun-win11-23h2-pro-arm64-16-${{ github.run_id }}",
               "is_cirun": "true"
             }
           ]

--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -64,7 +64,7 @@ jobs:
             },
             {
               "arch": "arm64",
-              "os": "cirun-win11-23h2-pro-arm64-16-${{ github.run_id }}",
+              "os": "cirun-win11-23h2-pro-arm64-16--${{ github.run_id }}",
               "is_cirun": "true"
             }
           ]

--- a/.github/workflows/schedule-swift-toolchain-windows-arm64.yml
+++ b/.github/workflows/schedule-swift-toolchain-windows-arm64.yml
@@ -16,10 +16,10 @@ jobs:
       create_release: false
       create_snapshot: false
       windows_build_arch: arm64
-      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-2025-03-13--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
-      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-2025-03-13--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
-      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-2025-03-13--{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
-      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-2025-03-13--{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
+      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
+      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
+      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
+      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
       android_api_level: 28
       build_android: false
     secrets: inherit

--- a/.github/workflows/schedule-swift-toolchain-windows-arm64.yml
+++ b/.github/workflows/schedule-swift-toolchain-windows-arm64.yml
@@ -16,10 +16,10 @@ jobs:
       create_release: false
       create_snapshot: false
       windows_build_arch: arm64
-      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
-      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
-      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
-      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
+      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
+      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
+      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16--{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
+      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64--{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
       android_api_level: 28
       build_android: false
     secrets: inherit

--- a/.github/workflows/schedule-swift-toolchain.yml
+++ b/.github/workflows/schedule-swift-toolchain.yml
@@ -14,10 +14,10 @@ jobs:
     uses: ./.github/workflows/build-toolchain.yml
     with:
       windows_build_arch: amd64
-      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-2025-03-13--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
-      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-2025-03-13--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
-      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-2025-03-13--{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
-      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-2025-03-13--{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
+      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
+      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
+      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
+      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
       android_api_level: 28
       build_android: true
     secrets: inherit

--- a/.github/workflows/schedule-swift-toolchain.yml
+++ b/.github/workflows/schedule-swift-toolchain.yml
@@ -14,10 +14,10 @@ jobs:
     uses: ./.github/workflows/build-toolchain.yml
     with:
       windows_build_arch: amd64
-      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16-{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
-      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64-{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
-      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16-{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
-      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64-{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
+      windows_x64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-16--{0}', github.run_id) || 'swift-build-windows-latest-8-cores' }}
+      windows_x64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-x64-64--{0}', github.run_id) || 'swift-build-windows-latest-64-cores' }}
+      windows_arm64_default_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-16--{0}', github.run_id) || 'swift-build-windows-arm64-latest-8-cores' }}
+      windows_arm64_compilers_runner: ${{ vars.USE_CIRUN == 'true' && format('cirun-win11-23h2-pro-arm64-64--{0}', github.run_id) || 'swift-build-windows-arm64-latest-32-cores' }}
       android_api_level: 28
       build_android: true
     secrets: inherit


### PR DESCRIPTION
In preparation to update vm images, switch job definitions targeting main branch to use a generic label with no date, e.g.: `cirun-win11-23h2-pro-x64-16` instead of `cirun-win11-23h2-pro-x64-16-2025-03-13`

This way we can update the image by modifying `.cirun.yml` without touching these files.
