### PR TITLE
Rename msi's and cab's to include asserts 

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -3730,7 +3730,7 @@ jobs:
               -p:WORKAROUND_MIMALLOC_ISSUE_997=false `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/bld.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/bld/asserts/bld.asserts.wixproj
 
       - name: Package CLI Tools
         run: |
@@ -3743,7 +3743,7 @@ jobs:
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/cli.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/cli/asserts/cli.asserts.wixproj
 
       - name: Package Debugging Tools
         run: |
@@ -3756,7 +3756,7 @@ jobs:
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/dbg.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/dbg/asserts/dbg.asserts.wixproj
 
       - name: Package IDE Tools
         run: |
@@ -3769,7 +3769,7 @@ jobs:
               -p:ImageRoot=${{ github.workspace }}/BuildRoot/Library/Developer `
               -p:ProductVersion=${{ inputs.swift_version }} `
               -p:ProductArchitecture=${{ matrix.arch }} `
-              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/ide.wixproj
+              ${{ github.workspace }}/SourceCache/swift-installer-scripts/platforms/Windows/ide/asserts/ide.asserts.wixproj
 
       - name: Package Runtime
         run: |
@@ -3792,41 +3792,41 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.cab
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.cab
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.cab
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.cab
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.msi
             ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/rtl.cab
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-bld-msi
+          name: Windows-${{ matrix.arch }}-bld-asserts-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/bld.asserts.cab
       - uses: actions/upload-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-cli-msi
+          name: Windows-${{ matrix.arch }}-cli-asserts-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/cli.asserts.cab
       - uses: actions/upload-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-dbg-msi
+          name: Windows-${{ matrix.arch }}-dbg-asserts-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/dbg.asserts.cab
       - uses: actions/upload-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-ide-msi
+          name: Windows-${{ matrix.arch }}-ide-asserts-msi
           path: |
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.msi
-            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.cab
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.msi
+            ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}/ide.asserts.cab
 
       - uses: actions/upload-artifact@v4
         with:
@@ -4207,19 +4207,19 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-bld-msi
+          name: Windows-${{ matrix.arch }}-bld-asserts-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-cli-msi
+          name: Windows-${{ matrix.arch }}-cli-asserts-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-dbg-msi
+          name: Windows-${{ matrix.arch }}-dbg-asserts-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:
-          name: Windows-${{ matrix.arch }}-ide-msi
+          name: Windows-${{ matrix.arch }}-ide-asserts-msi
           path: ${{ github.workspace }}/BinaryCache/installer/Release/${{ matrix.arch }}
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
[swiftlang/swift-installer-scripts/pull/428](https://github.com/swiftlang/swift-installer-scripts/pull/428/files) Changes names of msi's and cab's containing toolchain files to have the build variant in the name (i.e. `asserts`). Reflect this change in our GHA scripts.