### PR TITLE
CIRun: Remove old "cirun-win11-23h2" labels

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -21,7 +21,6 @@ runners:
     instance_type: Standard_D16plds_v5
     machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-24h2-pro-arm64/versions/2025.08.15"
     labels:
-      - cirun-win11-23h2-pro-arm64-16 # TODO(DEVEX-3260): Remove once unused
       - cirun-win11-pro-arm64-16
     extra_config:
       enable_public_ip: true
@@ -33,7 +32,6 @@ runners:
     instance_type: Standard_D64plds_v5
     machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-24h2-pro-arm64/versions/2025.08.15"
     labels:
-      - cirun-win11-23h2-pro-arm64-64 # TODO(DEVEX-3260): Remove once unused
       - cirun-win11-pro-arm64-64
     extra_config:
       enable_public_ip: true
@@ -45,7 +43,6 @@ runners:
     instance_type: Standard_F16s_v2
     machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-24h2-pro-x64/versions/2025.08.15"
     labels:
-      - cirun-win11-23h2-pro-x64-16 # TODO(DEVEX-3260): Remove once unused
       - cirun-win11-pro-x64-16
     extra_config:
       enable_public_ip: true
@@ -57,7 +54,6 @@ runners:
     instance_type: Standard_D64ads_v5
     machine_image: "/subscriptions/88c2ce23-b441-4d79-8f1c-50d9bc95ed08/resourceGroups/Win-CI/providers/Microsoft.Compute/galleries/base_images/images/win11-24h2-pro-x64/versions/2025.08.15"
     labels:
-      - cirun-win11-23h2-pro-x64-64 # TODO(DEVEX-3260): Remove once unused
       - cirun-win11-pro-x64-64
     extra_config:
       enable_public_ip: true


### PR DESCRIPTION
I switched our main branch away from using these labels a week ago since they baked in the specific OS version number and we were updating (and will again in the future). They are now unused.