### PR TITLE
Use built compilers since we are not isntalling pinned toolchain for …

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -2163,7 +2163,7 @@ jobs:
           android-api-level: ${{ inputs.ANDROID_API_LEVEL }}
           android-clang-version: ${{ inputs.ANDROID_CLANG_VERSION }}
           ndk-path: ${{ steps.setup-ndk.outputs.ndk-path }}
-          pinned-compilers: '@("C", "CXX")'
+          built-compilers: '@("C", "CXX")'
           cmake-defines: |
             @{
               'BUILD_SHARED_LIBS' = "YES";


### PR DESCRIPTION
…this job