### PR TITLE
Build bloaty using cl

### DIFF
--- a/.github/workflows/release-swift-toolchain-binary-sizes.yml
+++ b/.github/workflows/release-swift-toolchain-binary-sizes.yml
@@ -186,7 +186,7 @@ jobs:
           #     support g++11 (required by google/bloaty -> google/re2).
           #  2. clang-cl fails on google/bloaty -> protocolfbuffers/protobuf due to
           #     https://github.com/protocolbuffers/protobuf/issues/6503.
-          compiler: ${{ matrix.arch == 'arm64' && 'cl' || '' }}
+          compiler: 'cl' 
 
       - name: Generate BigQuery table data
         run: |


### PR DESCRIPTION
Looks like lateast windows image is causing an issue build bloaty (see [error](https://github.com/thebrowsercompany/swift-build/actions/runs/18851299374/job/53810923378)). ARM64 which was building on msvc did not have this issue. so switching to always use msvc toolchain to build bloaty for both architectures.