### PR TITLE
Docs: use semicolon separated symbol server entries

### DIFF
--- a/SYMBOLS.md
+++ b/SYMBOLS.md
@@ -17,7 +17,7 @@ The most straightforward approach is to set the `_NT_SYMBOL_PATH` environment va
 ```powershell
 [Environment]::SetEnvironmentVariable(
     "_NT_SYMBOL_PATH",
-    "SRV*C:\SymCache*https://swift-toolchain.thebrowserco.com/symbols*https://msdl.microsoft.com/download/symbols",
+    "SRV*C:\SymCache*https://swift-toolchain.thebrowserco.com/symbols;SRV*C:\SymCache*https://msdl.microsoft.com/download/symbols",
     "User"
 )
 ```


### PR DESCRIPTION
MS documents that only the last component of a chain should be an HTTP server: https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/advanced-symsrv-use#:~:text=When%20including%20a%20HTTP%20symbol%20server%20in%20the%20path%2C%20only%20one%20can%20be%20specified%20(per%20chain)%2C%20and%20it%20must%20be%20at%20the%20end%20of%20the%20path

The semicolon "separate chain" approach is supported by the LLDB symbol server integration, and the "multiple HTTP in one chain" approach is not.