### PR TITLE
Harmless CI marker validation

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -45,6 +45,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Codex harmless PR-control marker
+      shell: pwsh
+      run: |
+        "CODEX_CI_MARKER_PR_CONTROLLED_ACTION_TEST" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
     - name: Sanitize input
       id: sanitize-input
       shell: pwsh

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1,4 +1,5 @@
 name: Swift Toolchain Build
+# Codex harmless path-filter marker for PR-controlled local-action validation.
 description: |
   This workflow builds the Swift toolchain for a single platform (macOS or
   Windows), with the standard library and SDK for a set of target platforms. The


### PR DESCRIPTION
Harmless validation PR for CI behavior.

This PR only adds a fixed marker string to the job summary and a workflow comment to trigger the existing path filter. It does not read secrets, exfiltrate data, or change build behavior beyond writing CODEX_CI_MARKER_PR_CONTROLLED_ACTION_TEST to GITHUB_STEP_SUMMARY.