### PR TITLE
Make Windows toolchain CAS actions portable

### DIFF
--- a/.github/actions/restore-cas/action.yml
+++ b/.github/actions/restore-cas/action.yml
@@ -78,7 +78,10 @@ runs:
           Write-Host "$cas_tgz file size $FileSize bytes"
           New-Item -ItemType Directory -Path "$cas_path" | Out-Null
           Push-Location "$cas_path"
-          tar --force-local -xf "$temp_path" -C .
+          tar -xf "$temp_path" -C .
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to extract $cas_tgz"
+          }
           Pop-Location
           Remove-Item -Force "$temp_path"
           Write-Host "CAS restored at $cas_path."

--- a/.github/actions/save-cas/action.yml
+++ b/.github/actions/save-cas/action.yml
@@ -75,13 +75,17 @@ runs:
           $temp_path = "$temp_dir\$cas_tgz"
           Get-PSDrive
           Push-Location "$cas_path"
-          tar --sparse --force-local -cf "$temp_path" *
+          tar -cf "$temp_path" *
           if ($LASTEXITCODE -ne 0) {
             Write-Host "tar failed, creating an empty tarball instead"
             if (Test-Path "$temp_path") {
               Remove-Item "$temp_path" -Force
             }
-            tar --force-local -cf "$temp_path" --files-from $null
+            tar -cf "$temp_path" -T NUL
+            if ($LASTEXITCODE -ne 0) {
+              Pop-Location
+              throw "Failed to create $cas_tgz"
+            }
           }
           Pop-Location
           $FileSize = (Get-Item $temp_path).Length


### PR DESCRIPTION
Windows Server 2025 runners use bsdtar, which rejects the GNU-only `--force-local` and `--sparse` flags in the CAS actions. Restores with existing caches fail before builds start, and saves would fail before upload.

Fix: use portable archive arguments, a Windows-safe empty archive fallback, and explicit exit checks so corrupt restores or failed saves stop with the real error.