### PR TITLE
Decode Swift compiler sources as UTF-8

### DIFF
--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1401,8 +1401,8 @@ jobs:
               'LLVM_VERSION_SUFFIX' = "";
               'LLVM_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
               'SWIFT_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
-              'CMAKE_C_FLAGS' = "${{ inputs.use_host_toolchain && '/source-charset:utf-8' || '-fuse-ld=lld' }}";
-              'CMAKE_CXX_FLAGS' = "${{ inputs.use_host_toolchain && '/source-charset:utf-8' || '-fuse-ld=lld' }}";
+              'CMAKE_C_FLAGS' = "${{ inputs.build_os == 'Windows' && inputs.use_host_toolchain && '/source-charset:utf-8' || !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
+              'CMAKE_CXX_FLAGS' = "${{ inputs.build_os == 'Windows' && inputs.use_host_toolchain && '/source-charset:utf-8' || !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
               'CMAKE_Swift_FLAGS' = "${{ !inputs.use_host_toolchain && '-use-ld=lld' || '' }}";
             }
 
@@ -7285,8 +7285,8 @@ jobs:
               'LLVM_VERSION_SUFFIX' = "";
               'LLVM_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
               'SWIFT_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
-              'CMAKE_C_FLAGS' = "${{ inputs.use_host_toolchain && '/source-charset:utf-8' || '-fuse-ld=lld' }}";
-              'CMAKE_CXX_FLAGS' = "${{ inputs.use_host_toolchain && '/source-charset:utf-8' || '-fuse-ld=lld' }}";
+              'CMAKE_C_FLAGS' = "${{ inputs.build_os == 'Windows' && inputs.use_host_toolchain && '/source-charset:utf-8' || !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
+              'CMAKE_CXX_FLAGS' = "${{ inputs.build_os == 'Windows' && inputs.use_host_toolchain && '/source-charset:utf-8' || !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
               'CMAKE_Swift_FLAGS' = "${{ !inputs.use_host_toolchain && '-use-ld=lld' || '' }}";
             }
 

--- a/.github/workflows/swift-toolchain.yml
+++ b/.github/workflows/swift-toolchain.yml
@@ -1401,8 +1401,8 @@ jobs:
               'LLVM_VERSION_SUFFIX' = "";
               'LLVM_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
               'SWIFT_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_CXX_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
+              'CMAKE_C_FLAGS' = "${{ inputs.use_host_toolchain && '/source-charset:utf-8' || '-fuse-ld=lld' }}";
+              'CMAKE_CXX_FLAGS' = "${{ inputs.use_host_toolchain && '/source-charset:utf-8' || '-fuse-ld=lld' }}";
               'CMAKE_Swift_FLAGS' = "${{ !inputs.use_host_toolchain && '-use-ld=lld' || '' }}";
             }
 
@@ -7285,8 +7285,8 @@ jobs:
               'LLVM_VERSION_SUFFIX' = "";
               'LLVM_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
               'SWIFT_PARALLEL_LINK_JOBS' = "${{ steps.setup-context.outputs.link-jobs }}";
-              'CMAKE_C_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
-              'CMAKE_CXX_FLAGS' = "${{ !inputs.use_host_toolchain && '-fuse-ld=lld' || '' }}";
+              'CMAKE_C_FLAGS' = "${{ inputs.use_host_toolchain && '/source-charset:utf-8' || '-fuse-ld=lld' }}";
+              'CMAKE_CXX_FLAGS' = "${{ inputs.use_host_toolchain && '/source-charset:utf-8' || '-fuse-ld=lld' }}";
               'CMAKE_Swift_FLAGS' = "${{ !inputs.use_host_toolchain && '-use-ld=lld' || '' }}";
             }
 


### PR DESCRIPTION
Windows toolchain builds began failing on the VS 2026 runner because MSVC decodes Swift UTF-8 source files using the runner's legacy code page. This surfaces as `C3872` in `LocalizationLanguages.def` and blocks all four compiler variants.

Configure only the Windows host-MSVC compiler build and test paths with `/source-charset:utf-8`. This leaves the execution charset, Darwin builds, pinned-toolchain builds, and other dependency jobs unchanged.